### PR TITLE
Implement more accurate semicolon rules

### DIFF
--- a/grammar-declarations.js
+++ b/grammar-declarations.js
@@ -68,6 +68,7 @@ module.exports = {
       field('name', $._lhs_expression),
       optional($.type_params),
       seq('=', choice($.block, $._lhs_expression, $.type)),
+      $._lookback_semicolon,
     ),
 
   function_declaration: ($) =>
@@ -80,6 +81,7 @@ module.exports = {
       $._function_arg_list,
       optional(seq(':', field('return_type', $.type))),
       optional(field('body', $.block)),
+      $._lookback_semicolon,
     ),
 
   _function_arg_list: ($) => prec(1, seq('(', commaSep($.function_arg), ')')),
@@ -103,6 +105,6 @@ module.exports = {
       optional($.access_identifiers),
       optional(seq(':', optional(repeat('(')), field('type', $.type), optional(repeat(')')))),
       optional(seq(($._assignmentOperator, $.operator), $.expression)),
-      $._semicolon,
+      $._lookback_semicolon,
     ),
 };

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -32,9 +32,9 @@ module.exports = {
   map: ($) => prec(1, seq('[', commaSep1($.pair), ']')),
 
   // https://haxe.org/manual/expression-object-declaration.html
-  object: ($) => prec(1, seq('{', commaSep($.pair), '}')),
+  object: ($) => prec(1, seq('{', commaSep($.pair), $._closing_brace)),
 
-  structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), '}')),
+  structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace)),
   structure_type_pair: ($) => prec.left(seq(choice($.identifier), ':', $.type)),
 
   // Sub part of map and object literals

--- a/grammar.js
+++ b/grammar.js
@@ -12,9 +12,10 @@ const preprocessor_statement_end_tokens = ['else', 'end'];
 
 const haxe_grammar = {
   name: 'haxe',
+  externals: ($) => [$._lookback_semicolon, $._closing_brace_marker, $._closing_brace_unmarker],
   word: ($) => $.identifier,
   inline: ($) => [$.statement, $.expression],
-  extras: ($) => [$.comment, /[\s\uFEFF\u2060\u200B\u00A0]/],
+  extras: ($) => [$.comment, /[\s\uFEFF\u2060\u200B\u00A0]/, $._closing_brace_unmarker],
   supertypes: ($) => [$.declaration],
   conflicts: ($) => [
     [$.block, $.object],
@@ -40,20 +41,17 @@ const haxe_grammar = {
       // Use prec.left to favor rules that end SOONER
       // this means a semicolon ends the statement.
       prec.left(
-        seq(
-          choice(
-            $.preprocessor_statement,
-            $.import_statement,
-            $.using_statement,
-            $.package_statement,
-            $.declaration,
-            $.expression,
-            $.conditional_statement,
-            $.case_statement,
-            $.throw_statement,
-            $.block,
-          ),
-          optional($._semicolon),
+        choice(
+          $.preprocessor_statement,
+          $.import_statement,
+          $.using_statement,
+          $.package_statement,
+          $.declaration,
+          $.switch_expression,
+          seq($.expression, $._lookback_semicolon),
+          $.conditional_statement,
+          $.throw_statement,
+          $.block,
         ),
       ),
 
@@ -62,7 +60,7 @@ const haxe_grammar = {
         seq(
           '#',
           choice(
-            seq(token.immediate(choice(...preprocessor_statement_start_tokens)), $.statement),
+            seq(token.immediate(choice(...preprocessor_statement_start_tokens)), $.expression),
             token.immediate(choice(...preprocessor_statement_end_tokens)),
           ),
         ),
@@ -77,7 +75,7 @@ const haxe_grammar = {
     using_statement: ($) =>
       seq(alias('using', $.keyword), field('name', $._lhs_expression), $._semicolon),
 
-    throw_statement: ($) => prec.right(seq(alias('throw', $.keyword), $.expression)),
+    throw_statement: ($) => prec.right(seq(alias('throw', $.keyword), $.expression, $._lookback_semicolon)),
 
     _rhs_expression: ($) =>
       prec.right(choice($._literal, $.identifier, $.member_expression, $.call_expression)),
@@ -106,7 +104,9 @@ const haxe_grammar = {
         ),
       ),
 
-    switch_block: ($) => seq('{', repeat($.case_statement), '}'),
+    _closing_brace: ($) => seq($._closing_brace_marker, '}'),
+
+    switch_block: ($) => seq('{', repeat($.case_statement), $._closing_brace),
 
     case_statement: ($) =>
       prec.right(
@@ -215,7 +215,7 @@ const haxe_grammar = {
         ),
       ),
 
-    block: ($) => seq('{', repeat($.statement), '}'),
+    block: ($) => seq('{', repeat($.statement), $._closing_brace),
 
     metadata: ($) =>
       seq(

--- a/grammar.js
+++ b/grammar.js
@@ -100,7 +100,7 @@ const haxe_grammar = {
         seq(
           alias('switch', $.keyword),
           choice($.identifier, $._parenthesized_expression),
-          //           optional(alias($.switch_block, $.block)),
+          alias($.switch_block, $.block),
         ),
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -18,64 +18,56 @@
       "type": "PREC_LEFT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "CHOICE",
+            "type": "SYMBOL",
+            "name": "preprocessor_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "import_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "using_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "package_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "declaration"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "switch_expression"
+          },
+          {
+            "type": "SEQ",
             "members": [
-              {
-                "type": "SYMBOL",
-                "name": "preprocessor_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "import_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "using_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "package_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "declaration"
-              },
               {
                 "type": "SYMBOL",
                 "name": "expression"
               },
               {
                 "type": "SYMBOL",
-                "name": "conditional_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "case_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "throw_statement"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "block"
+                "name": "_lookback_semicolon"
               }
             ]
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_semicolon"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "type": "SYMBOL",
+            "name": "conditional_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "throw_statement"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "block"
           }
         ]
       }
@@ -114,7 +106,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "statement"
+                    "name": "expression"
                   }
                 ]
               },
@@ -235,6 +227,10 @@
           {
             "type": "SYMBOL",
             "name": "expression"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_lookback_semicolon"
           }
         ]
       }
@@ -352,9 +348,31 @@
                 "name": "_parenthesized_expression"
               }
             ]
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "switch_block"
+            },
+            "named": true,
+            "value": "block"
           }
         ]
       }
+    },
+    "_closing_brace": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_closing_brace_marker"
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
     },
     "switch_block": {
       "type": "SEQ",
@@ -371,8 +389,8 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "_closing_brace"
         }
       ]
     },
@@ -1100,8 +1118,8 @@
           }
         },
         {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "_closing_brace"
         }
       ]
     },
@@ -2105,6 +2123,10 @@
               ]
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lookback_semicolon"
         }
       ]
     },
@@ -2216,6 +2238,10 @@
               "type": "BLANK"
             }
           ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_lookback_semicolon"
         }
       ]
     },
@@ -2496,7 +2522,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "_semicolon"
+          "name": "_lookback_semicolon"
         }
       ]
     },
@@ -2817,8 +2843,8 @@
             ]
           },
           {
-            "type": "STRING",
-            "value": "}"
+            "type": "SYMBOL",
+            "name": "_closing_brace"
           }
         ]
       }
@@ -2877,8 +2903,8 @@
             ]
           },
           {
-            "type": "STRING",
-            "value": "}"
+            "type": "SYMBOL",
+            "name": "_closing_brace"
           }
         ]
       }
@@ -3329,6 +3355,10 @@
     {
       "type": "PATTERN",
       "value": "[\\s\\uFEFF\\u2060\\u200B\\u00A0]"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_closing_brace_unmarker"
     }
   ],
   "conflicts": [
@@ -3390,7 +3420,20 @@
     ]
   ],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "_lookback_semicolon"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_closing_brace_marker"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_closing_brace_unmarker"
+    }
+  ],
   "inline": [
     "statement",
     "expression"

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -412,10 +412,6 @@
           "named": true
         },
         {
-          "type": "case_statement",
-          "named": true
-        },
-        {
           "type": "cast_expression",
           "named": true
         },
@@ -1369,10 +1365,6 @@
           "named": true
         },
         {
-          "type": "case_statement",
-          "named": true
-        },
-        {
           "type": "cast_expression",
           "named": true
         },
@@ -1626,10 +1618,6 @@
           "named": true
         },
         {
-          "type": "block",
-          "named": true
-        },
-        {
           "type": "bool",
           "named": true
         },
@@ -1638,19 +1626,7 @@
           "named": true
         },
         {
-          "type": "case_statement",
-          "named": true
-        },
-        {
           "type": "cast_expression",
-          "named": true
-        },
-        {
-          "type": "conditional_statement",
-          "named": true
-        },
-        {
-          "type": "declaration",
           "named": true
         },
         {
@@ -1659,10 +1635,6 @@
         },
         {
           "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "import_statement",
           "named": true
         },
         {
@@ -1690,15 +1662,7 @@
           "named": true
         },
         {
-          "type": "package_statement",
-          "named": true
-        },
-        {
           "type": "pair",
-          "named": true
-        },
-        {
-          "type": "preprocessor_statement",
           "named": true
         },
         {
@@ -1722,15 +1686,7 @@
           "named": true
         },
         {
-          "type": "throw_statement",
-          "named": true
-        },
-        {
           "type": "type_trace_expression",
-          "named": true
-        },
-        {
-          "type": "using_statement",
           "named": true
         }
       ]
@@ -1971,6 +1927,10 @@
       "types": [
         {
           "type": "array",
+          "named": true
+        },
+        {
+          "type": "block",
           "named": true
         },
         {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,83 @@
+#include "tree_sitter/parser.h"
+#include "tree_sitter/alloc.h"
+
+enum TokenType {
+    LOOKBACK_SEMICOLON,
+    CLOSING_BRACE_MARKER,
+    CLOSING_BRACE_UNMARKER,
+};
+
+bool* tree_sitter_haxe_external_scanner_create(void) {
+    bool* just_saw_brace = ts_malloc(sizeof(bool));
+    *just_saw_brace = false;
+    return just_saw_brace;
+}
+
+void tree_sitter_haxe_external_scanner_destroy(bool* just_saw_brace) {
+    ts_free(just_saw_brace);
+}
+
+unsigned tree_sitter_haxe_external_scanner_serialize(
+    bool* just_saw_brace,
+    char* buffer
+) {
+    // printf("serialising\n");
+    buffer[0] = (char)(*just_saw_brace);
+    return 1;
+}
+
+void tree_sitter_haxe_external_scanner_deserialize(
+    bool* just_saw_brace,
+    const char* buffer,
+    unsigned length
+) {
+    if (length > 0) {
+        *just_saw_brace = buffer[0];
+    } else {
+        *just_saw_brace = false;
+    }
+}
+
+static bool is_whitespace(int32_t c) {
+    return c == ' ' || c == '\n';
+}
+
+bool tree_sitter_haxe_external_scanner_scan(
+    bool* just_saw_brace,
+    TSLexer* lexer,
+    const bool* valid_symbols
+) {
+    if (valid_symbols[LOOKBACK_SEMICOLON]) {
+        if (lexer->lookahead == ';') {
+            *just_saw_brace = false;
+            lexer->result_symbol = LOOKBACK_SEMICOLON;
+            lexer->advance(lexer, false);
+            return true;
+        } else if (*just_saw_brace) {
+            *just_saw_brace = false;
+            lexer->result_symbol = LOOKBACK_SEMICOLON;
+            return true;
+        }
+        return false;
+    }
+
+    if (valid_symbols[CLOSING_BRACE_MARKER]) {
+        lexer->mark_end(lexer);
+        while (is_whitespace(lexer->lookahead)) {
+            lexer->advance(lexer, true);
+        }
+        if (lexer->lookahead == '}') {
+            *just_saw_brace = true;
+            lexer->result_symbol = CLOSING_BRACE_MARKER;
+            return true;
+        }
+    }
+
+    if (valid_symbols[CLOSING_BRACE_UNMARKER] && *just_saw_brace && !(lexer->lookahead == '}' || is_whitespace(lexer->lookahead))) {
+        *just_saw_brace = false;
+        lexer->result_symbol = CLOSING_BRACE_UNMARKER;
+        return true;
+    }
+
+    return false;
+}

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -58,15 +58,13 @@ if (true) {
 parenthesis
 ===================
 
-a = (1+1);
+(1+1);
 
 ---
 
 (module
-  (identifier) 
-  (operator)
   (integer)
-  (operator) 
+  (operator)
   (integer)
 )
 
@@ -74,13 +72,11 @@ a = (1+1);
 subscript_expression
 ===================
 
-a = b[1];
+b[1];
 
 ---
 
 (module
-  (identifier) 
-  (operator)
   (subscript_expression
     (identifier)
     (integer)
@@ -91,13 +87,11 @@ a = b[1];
 subscript_expression
 ===================
 
-a = b[c + 1];
+a[b + 1];
 
 ---
 
 (module
-  (identifier) 
-  (operator)
   (subscript_expression
     (identifier)
     (identifier)

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -180,14 +180,14 @@ switch (x) {
 ---
 
 (module
-  (switch_expression (keyword) (identifier))
+  (switch_expression (keyword) (identifier)
   (block
-    (case_statement 
+    (case_statement
       (keyword)
-      (integer) 
+      (integer)
       (call_expression (identifier))
     )
-  )
+  ))
 )
 
 ===================
@@ -203,53 +203,68 @@ switch (x) {
 ---
 
 (module
-  (switch_expression (keyword) (identifier))
+  (switch_expression (keyword) (identifier)
   (block
-    (case_statement 
+    (case_statement
       (keyword)
-      (integer) 
+      (integer)
       (call_expression (identifier))
     )
-    (case_statement 
+    (case_statement
       (keyword)
-      (integer) 
+      (integer)
       (call_expression (identifier))
     )
-    (case_statement 
+    (case_statement
       (keyword)
       (call_expression (identifier))
     )
-  )
+  ))
 )
 
 ===================
 case expr statement in case.
 ===================
 
-case "1": func();
+switch a {
+  case "1": func();
+}
 
 ---
 
 (module
-  (case_statement 
+  (switch_expression
+  (keyword)
+        (identifier)
+        (block
+  (case_statement
     (keyword)
-    (string) 
+    (string)
     (call_expression (identifier))
-  )
+  )))
 )
 
 ===================
 case expr with member_expression in case.
 ===================
 
-case "1".code: func();
+switch a {
+  case "1".code: func();
+}
 
 ---
 
 (module
-  (case_statement 
+  (switch_expression
     (keyword)
-    (member_expression (string) (identifier))
-    (call_expression (identifier))
-  )
+    (identifier)
+      (block
+        (case_statement
+          (keyword)
+          (member_expression
+            (string)
+            (identifier))
+          (call_expression
+            (identifier)))))
 )
+

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -555,7 +555,7 @@ class main {
 simple pair literal 
 ===================
 
-x:1
+x:1;
 
 ---
 
@@ -567,7 +567,7 @@ x:1
 simple map pair literal 
 ===================
 
-"test"=>1
+"test"=>1;
 
 ---
 

--- a/test/corpus/semicolons.txt
+++ b/test/corpus/semicolons.txt
@@ -1,0 +1,115 @@
+===================
+Omitted semicolon var declaration literal
+===================
+
+var a = 10
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (integer)
+    (MISSING _lookback_semicolon)
+  )
+)
+
+===================
+Omitted semicolon var declaration blocks
+===================
+
+var a = {}
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (object)
+  )
+)
+
+===================
+Omitted semicolon var declaration block space
+===================
+
+var a = { }
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (object)
+  )
+)
+
+===================
+Omitted semicolon var declaration block newline
+===================
+
+var a = {
+}
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (object)
+  )
+)
+
+===================
+Omitted semicolon var declaration object
+===================
+
+var a = {
+  a: "hello"
+}
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (object (pair (identifier) (string)))
+  )
+)
+
+===================
+Omitted semicolon var declaration binary expression
+===================
+
+var a = 10 + {}
+
+---
+(module
+  (variable_declaration
+    (keyword)
+    (identifier)
+    (operator)
+    (integer)
+    (operator)
+    (object)
+  )
+)
+
+===================
+Omitted semicolon line after block
+===================
+
+{}test
+
+---
+(module
+  (object)
+  (identifier)
+  (MISSING _lookback_semicolon)
+)
+


### PR DESCRIPTION
Haxe semicolon rules are a bit weird. In most places, a semicolon is required unless the previous token was `}`. The haxe parser implements this by looking back at the previous token:
https://github.com/HaxeFoundation/haxe/blob/62854a7c2947ca95fd7b85a80d7e056cbf1d4d41/src/syntax/grammar.mly#L105-L114

I've added an [external scanner](https://tree-sitter.github.io/tree-sitter/creating-parsers#external-scanners) to do something similar here, and it seems to be doing an alright job.

This could be further improved in this case:
```haxe
a {} // this should be: a; {}
```
Here, haxe gives a missing semicolon error, but currently there is no useful error given by the grammar here:
```
(module
  (ERROR (identifier))
  (object)
)
```

This would be the test case for this:
```
===================
Omitted semicolon before block
===================
test{}
---
(module
  (identifier)
  (MISSING _lookback_semicolon)
  (object)
)
```

