### PR TITLE
Highlight type names and package names separately

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -69,15 +69,33 @@ const haxe_grammar = {
     package_statement: ($) =>
       seq(
         alias('package', $.keyword),
-        optional(field('name', $._lhs_expression)),
+        optional(field('name', seq(repeat(seq($.package_name, '.')), $.package_name))),
         $._semicolon
       ),
 
+    package_name: ($) => $._camelCaseIdentifier,
+    type_name: ($) => $._pascalCaseIdentifier,
     import_statement: ($) =>
-      seq(alias('import', $.keyword), field('name', $._lhs_expression), $._semicolon),
+      seq(
+        alias('import', $.keyword),
+        seq(
+          repeat(seq($.package_name, '.')),
+          repeat(seq($.type_name, '.')),
+          seq($.type_name, optional(seq('.', alias($._camelCaseIdentifier, $.identifier)))),
+        ),
+        $._semicolon
+      ),
 
     using_statement: ($) =>
-      seq(alias('using', $.keyword), field('name', $._lhs_expression), $._semicolon),
+      seq(
+        alias('using', $.keyword),
+        seq(
+          repeat(seq($.package_name, '.')),
+          repeat(seq($.type_name, '.')),
+          $.type_name
+        ),
+        $._semicolon
+      ),
 
     throw_statement: ($) =>
       prec.right(seq(alias('throw', $.keyword), $.expression, $._lookback_semicolon)),
@@ -269,6 +287,8 @@ const haxe_grammar = {
     keyword: ($) => prec.right(choice(...keywords)),
     identifier: ($) => /[a-zA-Z_]+[a-zA-Z0-9]*/,
     // Hidden Nodes in tree.
+    _camelCaseIdentifier: ($) => /[a-z_]+[a-zA-Z0-9]*/,
+    _pascalCaseIdentifier: ($) => /[A-Z]+[a-zA-Z0-9]*/,
     _semicolon: ($) => $._lookback_semicolon,
   },
 };

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -21,23 +21,6 @@
 
 ; Declarations
 ; ------------
-(import_statement name: [
-  (identifier) @type
-	(_ (identifier) @type)
-	(_(_ (identifier) @type))
-	(_(_(_ (identifier) @type)))
-	(_(_(_(_ (identifier) @type))))
-	(_(_(_(_(_ (identifier) @type)))))
-])
-
-; lol this is jank but okay.
-; (import_statement name: (_ (identifier) @type))
-; (import_statement name: (_(_ (identifier) @type)))
-; (import_statement name: (_(_(_ (identifier) @type))))
-; (import_statement name: (_(_(_(_ (identifier) @type)))))
-; (import_statement name: (_(_(_(_(_ (identifier) @type))))))
-
-(package_statement name: (identifier) @type)
 
 (class_declaration name: (identifier) @type.definition)
 (class_declaration super_class_name: (identifier) @type.definition)
@@ -68,6 +51,8 @@
 ; --------
 [(keyword) (null)] @keyword
 ; (type) @type
+(type_name) @type
+(package_name) @module
 (type (identifier) !built_in) @type
 (type built_in: (identifier)) @type.builtin
 [(integer) (float)] @number

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -150,8 +150,29 @@
               "type": "FIELD",
               "name": "name",
               "content": {
-                "type": "SYMBOL",
-                "name": "_lhs_expression"
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "package_name"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "."
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "package_name"
+                  }
+                ]
               }
             },
             {
@@ -164,6 +185,14 @@
           "name": "_semicolon"
         }
       ]
+    },
+    "package_name": {
+      "type": "SYMBOL",
+      "name": "_camelCaseIdentifier"
+    },
+    "type_name": {
+      "type": "SYMBOL",
+      "name": "_pascalCaseIdentifier"
     },
     "import_statement": {
       "type": "SEQ",
@@ -178,12 +207,76 @@
           "value": "keyword"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_lhs_expression"
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "package_name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  }
+                ]
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  }
+                ]
+              }
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "type_name"
+                },
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SEQ",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "."
+                        },
+                        {
+                          "type": "ALIAS",
+                          "content": {
+                            "type": "SYMBOL",
+                            "name": "_camelCaseIdentifier"
+                          },
+                          "named": true,
+                          "value": "identifier"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -204,12 +297,45 @@
           "value": "keyword"
         },
         {
-          "type": "FIELD",
-          "name": "name",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_lhs_expression"
-          }
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "package_name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  }
+                ]
+              }
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "type_name"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
+                  }
+                ]
+              }
+            },
+            {
+              "type": "SYMBOL",
+              "name": "type_name"
+            }
+          ]
         },
         {
           "type": "SYMBOL",
@@ -3349,6 +3475,14 @@
     "identifier": {
       "type": "PATTERN",
       "value": "[a-zA-Z_]+[a-zA-Z0-9]*"
+    },
+    "_camelCaseIdentifier": {
+      "type": "PATTERN",
+      "value": "[a-z_]+[a-zA-Z0-9]*"
+    },
+    "_pascalCaseIdentifier": {
+      "type": "PATTERN",
+      "value": "[A-Z]+[a-zA-Z0-9]*"
     },
     "_semicolon": {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -955,28 +955,25 @@
   {
     "type": "import_statement",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "member_expression",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
+          "type": "identifier",
+          "named": true
+        },
+        {
           "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "package_name",
+          "named": true
+        },
+        {
+          "type": "type_name",
           "named": true
         }
       ]
@@ -1485,19 +1482,24 @@
     "fields": {}
   },
   {
+    "type": "package_name",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "package_statement",
     "named": true,
     "fields": {
       "name": {
-        "multiple": false,
+        "multiple": true,
         "required": false,
         "types": [
           {
-            "type": "identifier",
-            "named": true
+            "type": ".",
+            "named": false
           },
           {
-            "type": "member_expression",
+            "type": "package_name",
             "named": true
           }
         ]
@@ -2179,6 +2181,11 @@
     }
   },
   {
+    "type": "type_name",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "type_param",
     "named": true,
     "fields": {},
@@ -2336,28 +2343,21 @@
   {
     "type": "using_statement",
     "named": true,
-    "fields": {
-      "name": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "identifier",
-            "named": true
-          },
-          {
-            "type": "member_expression",
-            "named": true
-          }
-        ]
-      }
-    },
+    "fields": {},
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": true,
       "types": [
         {
           "type": "keyword",
+          "named": true
+        },
+        {
+          "type": "package_name",
+          "named": true
+        },
+        {
+          "type": "type_name",
           "named": true
         }
       ]

--- a/test/corpus/import.txt
+++ b/test/corpus/import.txt
@@ -2,30 +2,46 @@
 import statement
 ===================
 
-import somePackage;
+import Type;
 
 ---
 
-(module (import_statement (keyword) (identifier)))
+(module (import_statement (keyword) (type_name)))
 
 ===================
 import statement with path
 ===================
 
-import my.other.package;
+import my.other.package.Type;
 
 ---
 
-(module 
-  (import_statement 
-    (keyword) 
-    (member_expression 
-      (identifier)
-      (member_expression 
-        (identifier)
-        (identifier)
-      )
-    )
+(module
+  (import_statement
+    (keyword)
+    (package_name)
+    (package_name)
+    (package_name)
+    (type_name)
+  )
+)
+
+===================
+import statement
+===================
+
+import my.other.package.Type.OtherType;
+
+---
+
+(module
+  (import_statement
+    (keyword)
+    (package_name)
+    (package_name)
+    (package_name)
+    (type_name)
+    (type_name)
   )
 )
 
@@ -33,36 +49,48 @@ import my.other.package;
 multiple import statements
 ===================
 
-import my.other.package;
-import banana;
+import my.other.package.Type;
+import Banana;
 import test.other.SomeClass;
 
 ---
 
-(module 
-  (import_statement 
+(module
+  (import_statement
     (keyword)
-    (member_expression 
-      (identifier)
-      (member_expression 
-        (identifier)
-        (identifier)
-      )
-    )
+    (package_name)
+    (package_name)
+    (package_name)
+    (type_name)
   )
-  (import_statement 
-    (keyword) 
+  (import_statement
+    (keyword)
+    (type_name)
+  )
+  (import_statement
+    (keyword)
+    (package_name)
+    (package_name)
+    (type_name)
+  )
+)
+
+===================
+import class field
+===================
+
+import my.other.package.Class.field;
+
+---
+
+(module
+  (import_statement
+    (keyword)
+    (package_name)
+    (package_name)
+    (package_name)
+    (type_name)
     (identifier)
-  )
-  (import_statement 
-    (keyword)
-    (member_expression 
-      (identifier)
-      (member_expression 
-        (identifier)
-        (identifier)
-      )
-    )
   )
 )
 
@@ -70,10 +98,10 @@ import test.other.SomeClass;
 using statement
 ===================
 
-using somePackage;
+using Type;
 
 ---
 
-(module (using_statement (keyword) (identifier)))
+(module (using_statement (keyword) (type_name)))
 
 

--- a/test/corpus/package.txt
+++ b/test/corpus/package.txt
@@ -16,7 +16,7 @@ package my;
 
 ---
 
-(module (package_statement (keyword) (identifier)))
+(module (package_statement (keyword) (package_name)))
 
 ===================
 Package Name with single path
@@ -26,13 +26,11 @@ package my.other;
 
 ---
 
-(module 
-  (package_statement 
-    (keyword) 
-    (member_expression
-      (identifier)
-      (identifier)
-    )
+(module
+  (package_statement
+    (keyword)
+    (package_name)
+    (package_name)
   )
 )
 
@@ -44,15 +42,11 @@ package my.other.package;
 
 ---
 
-(module 
-  (package_statement 
-    (keyword) 
-    (member_expression
-      (identifier)
-      (member_expression
-        (identifier)
-        (identifier)
-      )
-    )
+(module
+  (package_statement
+    (keyword)
+    (package_name)
+    (package_name)
+    (package_name)
   )
 )

--- a/test/highlight/import.hx
+++ b/test/highlight/import.hx
@@ -1,9 +1,28 @@
-import somePackage;
+import Type;
 // <- keyword
 //     ^ type
 
-import foo.bar;
-
-import my.other.package;
+import foo.Bar;
 // <- keyword
-//     ^ type
+//     ^ module
+//         ^ type
+
+import my.other.Type;
+// <- keyword
+//     ^ module
+//        ^ module
+//              ^ type
+
+import my.other.Type.Type;
+// <- keyword
+//     ^ module
+//        ^ module
+//              ^ type
+//                   ^ type
+
+import my.other.Type.field;
+// <- keyword
+//     ^ module
+//        ^ module
+//              ^ type
+//                   ^ variable

--- a/test/highlight/package.hx
+++ b/test/highlight/package.hx
@@ -4,12 +4,12 @@ package;
 
 package my;
 // <- keyword
-//      ^ type
-// (module (package_statement (identifier)))
+//      ^ module
+// (module (package_statement (package_name)))
 
 package my.other.package;
 // <- keyword
-//      ^ variable
-//         ^ variable
-//               ^ variable
-// (module (package_statement (identifier)(identifier)(identifier)))
+//      ^ module
+//         ^ module
+//               ^ module
+// (module (package_statement (package_name)(package_name)(package_name)))


### PR DESCRIPTION
Package names are now highlighted with `@module`, and type names are highlighted with `@type`.

This also removes the need for nested highlighting queries for package and import statements, so longer type paths will still highlight properly.

Before:
![image](https://github.com/user-attachments/assets/4c825572-3eb1-4ce0-a811-5f0638223b53)

After:
![image](https://github.com/user-attachments/assets/51dab128-00e9-4bf4-968a-073385431148)


