### PR TITLE
Add tree-sitter.json.

### DIFF
--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "haxe",
+      "camelcase": "Haxe",
+      "title": "Haxe",
+      "scope": "source.hx",
+      "file-types": [
+        "hx"
+      ],
+      "highlights": "queries/highlights.scm",
+      "injection-regex": "^haxe$",
+      "class-name": "TreeSitterHaxe"
+    }
+  ],
+  "metadata": {
+    "version": "0.13.0",
+    "license": "MIT",
+    "description": "A tree sitter parser for haxe",
+    "authors": [
+      {
+        "name": "Benjamin Van Treese",
+        "email": "vantreeseba@gmail.com"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/vantreeseba/tree-sitter-haxe"
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": true,
+    "node": true,
+    "python": true,
+    "rust": true,
+    "swift": true,
+    "zig": false
+  }
+}


### PR DESCRIPTION
This file is expected by `tree-sitter` CLI. 
It allows to infer file types, injection-regex, etc. during `tree-sitter test` [1].

[1] https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting#query-paths