### PR TITLE
Implement ternary conditional expressions (issue #40)

### DIFF
--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -37,11 +37,29 @@ module.exports = {
   structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace)),
   structure_type_pair: ($) => prec.left(seq(choice($.identifier), ':', $.type)),
 
-  // Sub part of map and object literals
+  // Sub part of map and object literals.
   pair: ($) =>
     prec.right(
       choice(
-        seq(choice($.identifier, $.string), ':', $.expression),
+        // Precedence -1, unlike the '=>' alternative below: `pair` is
+        // reachable as a bare _literal outside of {}/[] too (e.g. the
+        // "simple pair literal" test, `x:1;`), which is unambiguous on its
+        // own, but that reachability also makes `identifier ':' expression`
+        // a standing alternate reading of any ternary_expression's
+        // condition/consequence/alternative slot. Without a lower
+        // precedence here, that ambiguity silently resolves in favor of
+        // `pair` (tree-sitter doesn't even report it as a conflict needing
+        // a decision), swallowing a ternary's ':' and everything after it
+        // into the pair's value instead of leaving it for the ternary. -1
+        // only matters when there's an actual competing interpretation to
+        // lose to; it doesn't change the unambiguous {}/[] contexts or the
+        // bare `x:1;` case. Scoped to just this alternative -- an earlier
+        // attempt at giving `pair` as a whole -1 also demoted the '=>'
+        // alternative, which broke map literals (`[k => v]`) by letting
+        // array's generic `expression` chain (which can itself represent
+        // `_literal '=>' _literal` as an inline operator chain) win a
+        // now-lopsided tie it used to lose fairly.
+        prec(-1, seq(choice($.identifier, $.string), ':', $.expression)),
         seq(choice($.identifier, $._literal), '=>', $.expression),
       ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -156,6 +156,46 @@ const haxe_grammar = {
         seq($.identifier, 'in', choice(seq($.integer, $._rangeOperator, $.integer), $.identifier)),
       ),
 
+    // Deliberately excludes $.ternary_expression itself (and the statement-
+    // like forms below) so a bare, unparenthesized ternary can't be used as
+    // another ternary's condition -- `a ? b : c` must be wrapped in parens
+    // to serve as a condition. This keeps the grammar's only self-recursion
+    // on this rule in the `alternative` field, which is what gives
+    // `a ? b : c ? d : e` its right-associative ("else if" chain) reading
+    // instead of an ambiguous choice between two equally-valid nestings.
+    // prec(1, ...) on the whole choice, not just one branch: `pair`'s value
+    // slot is `$.expression`, which reaches every alternative below via
+    // ternary_expression's condition field, so any of them can be mid-parse
+    // when a '?' shows up. Higher precedence than `pair`'s default (0) means
+    // the parser shifts (keeps parsing toward the ternary) instead of
+    // reducing the pair immediately, so `x : y ? c : d` reads as
+    // `x : (y ? c : d)` rather than leaving `? c : d` dangling after a
+    // prematurely-closed pair.
+    _ternary_condition: ($) =>
+      prec(
+        1,
+        choice(
+          $._unaryExpression,
+          $.subscript_expression,
+          $.cast_expression,
+          $._parenthesized_expression,
+          seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
+        ),
+      ),
+
+    // https://haxe.org/manual/expression-ternary.html
+    ternary_expression: ($) =>
+      prec.right(
+        2,
+        seq(
+          field('condition', $._ternary_condition),
+          '?',
+          field('consequence', $.expression),
+          ':',
+          field('alternative', $.expression),
+        ),
+      ),
+
     expression: ($) =>
       choice(
         $._unaryExpression,
@@ -166,6 +206,7 @@ const haxe_grammar = {
         $.range_expression,
         $._parenthesized_expression,
         $.switch_expression,
+        $.ternary_expression,
         // simple expression, or chained.
         seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
         seq('return', optional($._rhs_expression)),
@@ -190,7 +231,15 @@ const haxe_grammar = {
       prec.right(
         seq(
           choice(field('object', choice('this', $.identifier)), field('literal', $._literal)),
-          choice(token('.'), seq(alias('?', $.operator), '.')),
+          // '?.' must be one atomic token (no space allowed, matching real
+          // Haxe syntax) rather than '?' and '.' as separate tokens. With
+          // them separate, `identifier '?'` is ambiguous between "start of
+          // safe-nav" and "start of a ternary_expression" -- resolving that
+          // needs to see whether '.' follows, i.e. 2 tokens of lookahead,
+          // more than LALR(1) has. Making '?.' atomic pushes the decision
+          // into the lexer (does the next char after '?' happen to be '.'?)
+          // instead of the parser.
+          choice(token('.'), alias(token(seq('?', '.')), $.operator)),
           repeat1(field('member', $._lhs_expression)),
         ),
       ),


### PR DESCRIPTION
Fixes #40 — ternary conditional expressions (`cond ? a : b`) were never given their own grammar rule at all. `?`/`:` fell through to the object-literal `pair` rule instead, producing an `ERROR` node for every ternary, not just ones involving generics as the issue title suggests.

**What's fixed**

Adds a `ternary_expression` rule, right-associative so `a?b:c?d:e` reads as `a?b:(c?d:e)`, with a restricted `_ternary_condition` (excludes a bare ternary as its own condition — must be parenthesized) so the grammar's only self-recursion is in the `alternative` field.

Two conflicts had to be resolved for real ternaries to actually parse, not just the new rule itself:

- `identifier '?'` was ambiguous with `member_expression`'s safe-navigation `?.`, since disambiguating needs to see whether `.` follows — 2 tokens of lookahead, more than LALR(1) has. Fixed by making `?.` one atomic token in the lexer instead of two separate tokens in the parser, so the lexer resolves it instead of the parser.
- `pair` is reachable as a bare `_literal` outside of `{}`/`[]` (see the existing "simple pair literal" test, `x:1;`), which stood as an alternate reading of any ternary's condition/consequence/alternative slot and silently won every tie — tree-sitter didn't even report it as a conflict needing a decision. Gave just `pair`'s `:` alternative (not `=>`, which is unrelated to this ambiguity and regressed map literals when I tried lowering it too) a precedence below the ternary's.

**Verified**

Full existing test corpus: 157/157 passing, no regressions. Plus your own `test/highlight/issue-40.hx` fixture — the `a > b ? 1 : -1` line now parses as a clean `ternary_expression`, confirmed directly.

**What's still broken, out of scope for this PR**

`a < b ? c : d` still doesn't parse — but neither does bare `a < b;` with no ternary involved at all. That's a separate, pre-existing ambiguity between comparison `<` and generic `type_params`, matching your own comment on the issue ("not really associated with ternary itself, but instead with how I was parsing the type params, causing the `<` symbol to make the parser go a bit wacky"). Your `test/highlight/issue-40.hx` fixture exercises both `<` and `>` — this PR fixes the `>` half; the `<` half needs its own fix to the type_params/comparison-operator ambiguity.