### PR TITLE
Fix/comparison operators vs type params

### DIFF
--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -40,6 +40,7 @@ module.exports = {
   // Sub part of map and object literals.
   pair: ($) =>
     prec.right(
+      1,
       choice(
         // Precedence -1, unlike the '=>' alternative below: `pair` is
         // reachable as a bare _literal outside of {}/[] too (e.g. the

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -37,11 +37,29 @@ module.exports = {
   structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace)),
   structure_type_pair: ($) => prec.left(seq(choice($.identifier), ':', $.type)),
 
-  // Sub part of map and object literals
+  // Sub part of map and object literals.
   pair: ($) =>
     prec.right(
       choice(
-        seq(choice($.identifier, $.string), ':', $.expression),
+        // Precedence -1, unlike the '=>' alternative below: `pair` is
+        // reachable as a bare _literal outside of {}/[] too (e.g. the
+        // "simple pair literal" test, `x:1;`), which is unambiguous on its
+        // own, but that reachability also makes `identifier ':' expression`
+        // a standing alternate reading of any ternary_expression's
+        // condition/consequence/alternative slot. Without a lower
+        // precedence here, that ambiguity silently resolves in favor of
+        // `pair` (tree-sitter doesn't even report it as a conflict needing
+        // a decision), swallowing a ternary's ':' and everything after it
+        // into the pair's value instead of leaving it for the ternary. -1
+        // only matters when there's an actual competing interpretation to
+        // lose to; it doesn't change the unambiguous {}/[] contexts or the
+        // bare `x:1;` case. Scoped to just this alternative -- an earlier
+        // attempt at giving `pair` as a whole -1 also demoted the '=>'
+        // alternative, which broke map literals (`[k => v]`) by letting
+        // array's generic `expression` chain (which can itself represent
+        // `_literal '=>' _literal` as an inline operator chain) win a
+        // now-lopsided tie it used to lose fairly.
+        prec(-1, seq(choice($.identifier, $.string), ':', $.expression)),
         seq(choice($.identifier, $._literal), '=>', $.expression),
       ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -156,6 +156,46 @@ const haxe_grammar = {
         seq($.identifier, 'in', choice(seq($.integer, $._rangeOperator, $.integer), $.identifier)),
       ),
 
+    // Deliberately excludes $.ternary_expression itself (and the statement-
+    // like forms below) so a bare, unparenthesized ternary can't be used as
+    // another ternary's condition -- `a ? b : c` must be wrapped in parens
+    // to serve as a condition. This keeps the grammar's only self-recursion
+    // on this rule in the `alternative` field, which is what gives
+    // `a ? b : c ? d : e` its right-associative ("else if" chain) reading
+    // instead of an ambiguous choice between two equally-valid nestings.
+    // prec(1, ...) on the whole choice, not just one branch: `pair`'s value
+    // slot is `$.expression`, which reaches every alternative below via
+    // ternary_expression's condition field, so any of them can be mid-parse
+    // when a '?' shows up. Higher precedence than `pair`'s default (0) means
+    // the parser shifts (keeps parsing toward the ternary) instead of
+    // reducing the pair immediately, so `x : y ? c : d` reads as
+    // `x : (y ? c : d)` rather than leaving `? c : d` dangling after a
+    // prematurely-closed pair.
+    _ternary_condition: ($) =>
+      prec(
+        1,
+        choice(
+          $._unaryExpression,
+          $.subscript_expression,
+          $.cast_expression,
+          $._parenthesized_expression,
+          seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
+        ),
+      ),
+
+    // https://haxe.org/manual/expression-ternary.html
+    ternary_expression: ($) =>
+      prec.right(
+        2,
+        seq(
+          field('condition', $._ternary_condition),
+          '?',
+          field('consequence', $.expression),
+          ':',
+          field('alternative', $.expression),
+        ),
+      ),
+
     expression: ($) =>
       choice(
         $._unaryExpression,
@@ -166,6 +206,7 @@ const haxe_grammar = {
         $.range_expression,
         $._parenthesized_expression,
         $.switch_expression,
+        $.ternary_expression,
         // simple expression, or chained.
         seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
         seq('return', optional($._rhs_expression)),
@@ -190,7 +231,15 @@ const haxe_grammar = {
       prec.right(
         seq(
           choice(field('object', choice('this', $.identifier)), field('literal', $._literal)),
-          choice(token('.'), seq(alias('?', $.operator), '.')),
+          // '?.' must be one atomic token (no space allowed, matching real
+          // Haxe syntax) rather than '?' and '.' as separate tokens. With
+          // them separate, `identifier '?'` is ambiguous between "start of
+          // safe-nav" and "start of a ternary_expression" -- resolving that
+          // needs to see whether '.' follows, i.e. 2 tokens of lookahead,
+          // more than LALR(1) has. Making '?.' atomic pushes the decision
+          // into the lexer (does the next char after '?' happen to be '.'?)
+          // instead of the parser.
+          choice(token('.'), alias(token(seq('?', '.')), $.operator)),
           repeat1(field('member', $._lhs_expression)),
         ),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -33,6 +33,7 @@ const haxe_grammar = {
     [$._rhs_expression, $._lhs_expression],
     [$._rhs_expression, $.subscript_expression],
     [$._lhs_expression, $.pair],
+    [$._ternary_condition, $.pair],
     [$._unaryExpression, $._ternary_condition, $.pair],
   ],
   rules: {
@@ -108,14 +109,28 @@ const haxe_grammar = {
     _rhs_expression: ($) =>
       prec(1, choice($._literal, $.identifier, $.member_expression, $.call_expression)),
 
+    // Restricted to the actual unary operator sets (_prefixUnaryOperator/
+    // _postfixUnaryOperator), not the fully generic $.operator (which also
+    // includes every binary operator). The generic version let e.g. `width <`
+    // match here treating '<' as a bogus "postfix unary" operator -- almost
+    // never an issue on its own since it's semantically nonsensical, but it
+    // created a second, equally error-free reading for comparison-conditioned
+    // ternaries inside parens (`(width < height ? width : height)`, matching
+    // real code in this depot): _unaryExpression could swallow "width <" as
+    // one expression, leaving a second, separate ternary_expression for just
+    // "height ? width : height" -- silently misparsing `a < b ? c : d` as
+    // `a < (b ? c : d)` with no ERROR node to catch it. This was a
+    // pre-existing latent bug, not introduced by the < vs. type_params fix
+    // above; it surfaced now because it happened to share a state with the
+    // newly-added ternary_expression.
     _unaryExpression: ($) =>
       prec.left(
         2,
         choice(
           // unary on LHS
-          seq($.operator, $._rhs_expression),
+          seq(alias($._prefixUnaryOperator, $.operator), $._rhs_expression),
           // unary on RHS
-          seq($._rhs_expression, $.operator),
+          seq($._rhs_expression, alias($._postfixUnaryOperator, $.operator)),
         ),
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -30,6 +30,10 @@ const haxe_grammar = {
     [$.function_declaration, $.variable_declaration],
     [$._prefixUnaryOperator, $._arithmeticOperator],
     [$._prefixUnaryOperator, $._postfixUnaryOperator],
+    [$._rhs_expression, $._lhs_expression],
+    [$._rhs_expression, $.subscript_expression],
+    [$._lhs_expression, $.pair],
+    [$._unaryExpression, $._ternary_condition, $.pair],
   ],
   rules: {
     module: ($) => seq(repeat($.statement)),
@@ -102,11 +106,11 @@ const haxe_grammar = {
     throw_statement: ($) => prec.right(seq('throw', $.expression, $._lookback_semicolon)),
 
     _rhs_expression: ($) =>
-      prec.right(choice($._literal, $.identifier, $.member_expression, $.call_expression)),
+      prec(1, choice($._literal, $.identifier, $.member_expression, $.call_expression)),
 
     _unaryExpression: ($) =>
       prec.left(
-        1,
+        2,
         choice(
           // unary on LHS
           seq($.operator, $._rhs_expression),
@@ -173,7 +177,7 @@ const haxe_grammar = {
     // prematurely-closed pair.
     _ternary_condition: ($) =>
       prec(
-        1,
+        2,
         choice(
           $._unaryExpression,
           $.subscript_expression,
@@ -186,7 +190,7 @@ const haxe_grammar = {
     // https://haxe.org/manual/expression-ternary.html
     ternary_expression: ($) =>
       prec.right(
-        2,
+        3,
         seq(
           field('condition', $._ternary_condition),
           '?',

--- a/test/corpus/binary_operators.txt
+++ b/test/corpus/binary_operators.txt
@@ -59,3 +59,104 @@ var x = 1 + y;
     (integer) (operator) (identifier)
   )
 )
+
+
+
+===================
+less than comparison
+===================
+
+var x = a < b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+greater than comparison
+===================
+
+var x = a > b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+less than or equal comparison
+===================
+
+var x = a <= b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+greater than or equal comparison
+===================
+
+var x = a >= b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+equality comparison
+===================
+
+var x = a == b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+inequality comparison
+===================
+
+var x = a != b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+less-than comparison does not get mistaken for a generic call's type params
+===================
+
+var x = a < b;
+var y = Vector<Float>(x);
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+  (variable_declaration (identifier) (operator)
+    (call_expression
+      (identifier)
+      (type_params (type (identifier)))
+      (identifier)
+    )
+  )
+)

--- a/test/corpus/ternary.txt
+++ b/test/corpus/ternary.txt
@@ -1,0 +1,106 @@
+===================
+simple ternary
+===================
+
+var x = a ? b : c;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+ternary with comparison condition, greater than
+===================
+
+var x = a > b ? c : d;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+ternary with comparison condition, less than
+===================
+
+var x = a < b ? c : d;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+nested ternary is right-associative
+===================
+
+var x = a ? b : c ? d : e;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (ternary_expression
+        (identifier)
+        (identifier)
+        (identifier)
+      )
+    )
+  )
+)
+
+===================
+ternary as a call argument
+===================
+
+foo(a ? b : c);
+
+---
+
+(module
+  (call_expression
+    (identifier)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)

--- a/test/corpus/ternary.txt
+++ b/test/corpus/ternary.txt
@@ -63,6 +63,28 @@ var x = a < b ? c : d;
 )
 
 ===================
+ternary with comparison condition in parens does not split the comparison off
+===================
+
+var x = (width < height ? width : height);
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
 nested ternary is right-associative
 ===================
 


### PR DESCRIPTION
Depends on #69 (this branch is built on top of it — `_ternary_condition`/`ternary_expression` are used directly in the fix and its conflict declarations). Should be reviewed/merged after that one.

Fixes the "deeper issue" mentioned on #40: comparison operators (`<`, `>`, `<=`, `>=`, `==`, `!=`) were being misparsed whenever they shared a state with `type_params` — `a < b` and `Vector<Float>(x)` share the identical prefix `identifier '<'`, and disambiguating them requires knowing whether a matching `>` (followed by `(`) eventually shows up, more lookahead than LALR(1) has.

**Root cause**

This was silently, statically resolved in favor of the generic-call reading, via `_lhs_expression`'s precedence advantage over `_rhs_expression` — never reported as a conflict, since precedence differences resolve reduce/reduce ties without erroring. So `a < b;` never parsed correctly, independent of ternary entirely — confirmed by testing bare `a < b;` with no `?`/`:` anywhere near it.

No static precedence can fix this without breaking the opposite direction — whichever reading wins by default, the other one breaks for real code somewhere.

**The fix**

Tie `_lhs_expression`/`_rhs_expression`/`subscript_expression`'s precedence and declare them as a genuine GLR conflict, so tree-sitter builds real fork-and-keep-the-survivor machinery instead of resolving statically. Verified both directions parse correctly and simultaneously:

```a < b; -> comparison
a < b ? c : d; -> ternary with comparison condition
Vector<Float>(x); -> generic call, type_params intact
foo<Int>(x); -> generic call
new Array<Int>(); -> unaffected
```

That tie exposed three more previously-hidden ties, each fixed with the minimum precedence bump needed to restore the original resolution (now explicit instead of implicit): `_lhs_expression` vs `pair` (revealed by `final x => ...`-shaped input), and a three-way tie among `_unaryExpression`/`_ternary_condition`/`pair`.

**A second bug, found by testing against real code**

Testing this against actual files (not just synthetic cases) turned up something worse than a parse error: `(width < height ? width : height)` silently misparsed as `width < (height ? width : height)`, splitting the comparison off from its own ternary. No `ERROR` node, so `has_error` checks alone would never catch it.

Root cause: `_unaryExpression`'s "postfix" alternative used the fully generic `$.operator` (every binary operator) instead of the real `_postfixUnaryOperator` set (`++`/`--` only). That let `width <` match as a bogus postfix-unary expression, which inside `_parenthesized_expression`'s `repeat1($.expression)` is a second, equally error-free reading alongside the correct one. This was a pre-existing latent bug, not introduced by this PR — it just happened to newly share a state with `ternary_expression`. Tried ranking the two readings apart with `prec.dynamic` twice (on `ternary_expression`, then on `_ternary_condition`'s chain alternative); neither worked, because both full derivations contain exactly one `ternary_expression` node either way, so the bonus lands on an identical node in both — a tie regardless. Fixed by restricting `_unaryExpression`'s prefix/postfix slots to their real operator sets (aliased back to `$.operator` so the tree shape is unchanged), removing the bogus reading instead of trying to out-rank it.

**Verified**

- Full corpus test suite: 185/185 (added ternary + comparison-operator coverage that had zero prior tests — that gap is exactly why the original bug went unnoticed).
- A graphify sweep of 5,001 real `.hx` files including away3d and starling: 0 extraction exceptions, edge count recovered from 317,891 to 330,359.
- 8 real ternary-with-comparison call sites found via grep across the same codebase; all resolve correctly except one that hits the already-documented, separately-scoped `_rhs_expression`/`_parenthesized_expression` gap mentioned on #69 (unrelated to this fix).