### PR TITLE
Fix/chain completeness return subscript postfix

### DIFF
--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -40,6 +40,7 @@ module.exports = {
   // Sub part of map and object literals.
   pair: ($) =>
     prec.right(
+      1,
       choice(
         // Precedence -1, unlike the '=>' alternative below: `pair` is
         // reachable as a bare _literal outside of {}/[] too (e.g. the

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -37,11 +37,29 @@ module.exports = {
   structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace)),
   structure_type_pair: ($) => prec.left(seq(choice($.identifier), ':', $.type)),
 
-  // Sub part of map and object literals
+  // Sub part of map and object literals.
   pair: ($) =>
     prec.right(
       choice(
-        seq(choice($.identifier, $.string), ':', $.expression),
+        // Precedence -1, unlike the '=>' alternative below: `pair` is
+        // reachable as a bare _literal outside of {}/[] too (e.g. the
+        // "simple pair literal" test, `x:1;`), which is unambiguous on its
+        // own, but that reachability also makes `identifier ':' expression`
+        // a standing alternate reading of any ternary_expression's
+        // condition/consequence/alternative slot. Without a lower
+        // precedence here, that ambiguity silently resolves in favor of
+        // `pair` (tree-sitter doesn't even report it as a conflict needing
+        // a decision), swallowing a ternary's ':' and everything after it
+        // into the pair's value instead of leaving it for the ternary. -1
+        // only matters when there's an actual competing interpretation to
+        // lose to; it doesn't change the unambiguous {}/[] contexts or the
+        // bare `x:1;` case. Scoped to just this alternative -- an earlier
+        // attempt at giving `pair` as a whole -1 also demoted the '=>'
+        // alternative, which broke map literals (`[k => v]`) by letting
+        // array's generic `expression` chain (which can itself represent
+        // `_literal '=>' _literal` as an inline operator chain) win a
+        // now-lopsided tie it used to lose fairly.
+        prec(-1, seq(choice($.identifier, $.string), ':', $.expression)),
         seq(choice($.identifier, $._literal), '=>', $.expression),
       ),
     ),

--- a/grammar.js
+++ b/grammar.js
@@ -156,6 +156,46 @@ const haxe_grammar = {
         seq($.identifier, 'in', choice(seq($.integer, $._rangeOperator, $.integer), $.identifier)),
       ),
 
+    // Deliberately excludes $.ternary_expression itself (and the statement-
+    // like forms below) so a bare, unparenthesized ternary can't be used as
+    // another ternary's condition -- `a ? b : c` must be wrapped in parens
+    // to serve as a condition. This keeps the grammar's only self-recursion
+    // on this rule in the `alternative` field, which is what gives
+    // `a ? b : c ? d : e` its right-associative ("else if" chain) reading
+    // instead of an ambiguous choice between two equally-valid nestings.
+    // prec(1, ...) on the whole choice, not just one branch: `pair`'s value
+    // slot is `$.expression`, which reaches every alternative below via
+    // ternary_expression's condition field, so any of them can be mid-parse
+    // when a '?' shows up. Higher precedence than `pair`'s default (0) means
+    // the parser shifts (keeps parsing toward the ternary) instead of
+    // reducing the pair immediately, so `x : y ? c : d` reads as
+    // `x : (y ? c : d)` rather than leaving `? c : d` dangling after a
+    // prematurely-closed pair.
+    _ternary_condition: ($) =>
+      prec(
+        1,
+        choice(
+          $._unaryExpression,
+          $.subscript_expression,
+          $.cast_expression,
+          $._parenthesized_expression,
+          seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
+        ),
+      ),
+
+    // https://haxe.org/manual/expression-ternary.html
+    ternary_expression: ($) =>
+      prec.right(
+        2,
+        seq(
+          field('condition', $._ternary_condition),
+          '?',
+          field('consequence', $.expression),
+          ':',
+          field('alternative', $.expression),
+        ),
+      ),
+
     expression: ($) =>
       choice(
         $._unaryExpression,
@@ -166,6 +206,7 @@ const haxe_grammar = {
         $.range_expression,
         $._parenthesized_expression,
         $.switch_expression,
+        $.ternary_expression,
         // simple expression, or chained.
         seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
         seq('return', optional($._rhs_expression)),
@@ -190,7 +231,15 @@ const haxe_grammar = {
       prec.right(
         seq(
           choice(field('object', choice('this', $.identifier)), field('literal', $._literal)),
-          choice(token('.'), seq(alias('?', $.operator), '.')),
+          // '?.' must be one atomic token (no space allowed, matching real
+          // Haxe syntax) rather than '?' and '.' as separate tokens. With
+          // them separate, `identifier '?'` is ambiguous between "start of
+          // safe-nav" and "start of a ternary_expression" -- resolving that
+          // needs to see whether '.' follows, i.e. 2 tokens of lookahead,
+          // more than LALR(1) has. Making '?.' atomic pushes the decision
+          // into the lexer (does the next char after '?' happen to be '.'?)
+          // instead of the parser.
+          choice(token('.'), alias(token(seq('?', '.')), $.operator)),
           repeat1(field('member', $._lhs_expression)),
         ),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -33,6 +33,7 @@ const haxe_grammar = {
     [$._rhs_expression, $._lhs_expression],
     [$._rhs_expression, $.subscript_expression],
     [$._lhs_expression, $.pair],
+    [$._ternary_condition, $.pair],
     [$._unaryExpression, $._ternary_condition, $.pair],
   ],
   rules: {
@@ -108,14 +109,28 @@ const haxe_grammar = {
     _rhs_expression: ($) =>
       prec(1, choice($._literal, $.identifier, $.member_expression, $.call_expression)),
 
+    // Restricted to the actual unary operator sets (_prefixUnaryOperator/
+    // _postfixUnaryOperator), not the fully generic $.operator (which also
+    // includes every binary operator). The generic version let e.g. `width <`
+    // match here treating '<' as a bogus "postfix unary" operator -- almost
+    // never an issue on its own since it's semantically nonsensical, but it
+    // created a second, equally error-free reading for comparison-conditioned
+    // ternaries inside parens (`(width < height ? width : height)`, matching
+    // real code in this depot): _unaryExpression could swallow "width <" as
+    // one expression, leaving a second, separate ternary_expression for just
+    // "height ? width : height" -- silently misparsing `a < b ? c : d` as
+    // `a < (b ? c : d)` with no ERROR node to catch it. This was a
+    // pre-existing latent bug, not introduced by the < vs. type_params fix
+    // above; it surfaced now because it happened to share a state with the
+    // newly-added ternary_expression.
     _unaryExpression: ($) =>
       prec.left(
         2,
         choice(
           // unary on LHS
-          seq($.operator, $._rhs_expression),
+          seq(alias($._prefixUnaryOperator, $.operator), $._rhs_expression),
           // unary on RHS
-          seq($._rhs_expression, $.operator),
+          seq($._rhs_expression, alias($._postfixUnaryOperator, $.operator)),
         ),
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -30,6 +30,10 @@ const haxe_grammar = {
     [$.function_declaration, $.variable_declaration],
     [$._prefixUnaryOperator, $._arithmeticOperator],
     [$._prefixUnaryOperator, $._postfixUnaryOperator],
+    [$._rhs_expression, $._lhs_expression],
+    [$._rhs_expression, $.subscript_expression],
+    [$._lhs_expression, $.pair],
+    [$._unaryExpression, $._ternary_condition, $.pair],
   ],
   rules: {
     module: ($) => seq(repeat($.statement)),
@@ -102,11 +106,11 @@ const haxe_grammar = {
     throw_statement: ($) => prec.right(seq('throw', $.expression, $._lookback_semicolon)),
 
     _rhs_expression: ($) =>
-      prec.right(choice($._literal, $.identifier, $.member_expression, $.call_expression)),
+      prec(1, choice($._literal, $.identifier, $.member_expression, $.call_expression)),
 
     _unaryExpression: ($) =>
       prec.left(
-        1,
+        2,
         choice(
           // unary on LHS
           seq($.operator, $._rhs_expression),
@@ -173,7 +177,7 @@ const haxe_grammar = {
     // prematurely-closed pair.
     _ternary_condition: ($) =>
       prec(
-        1,
+        2,
         choice(
           $._unaryExpression,
           $.subscript_expression,
@@ -186,7 +190,7 @@ const haxe_grammar = {
     // https://haxe.org/manual/expression-ternary.html
     ternary_expression: ($) =>
       prec.right(
-        2,
+        3,
         seq(
           field('condition', $._ternary_condition),
           '?',

--- a/grammar.js
+++ b/grammar.js
@@ -35,6 +35,7 @@ const haxe_grammar = {
     [$._lhs_expression, $.pair],
     [$._ternary_condition, $.pair],
     [$._unaryExpression, $._ternary_condition, $.pair],
+    [$._chain_term, $._ternary_condition],
   ],
   rules: {
     module: ($) => seq(repeat($.statement)),
@@ -175,6 +176,16 @@ const haxe_grammar = {
         seq($.identifier, 'in', choice(seq($.integer, $._rangeOperator, $.integer), $.identifier)),
       ),
 
+    // A chain term that may optionally carry a leading prefix-unary operator
+    // (`!y`, `-y`, etc.), used only in a chain's TAIL positions (never as a
+    // chain's head -- using this in head position reintroduces an extra
+    // reduce step that collides with the head's own shift/reduce decision
+    // and silently breaks even plain chains like `1 + 2`; confirmed by
+    // testing, not just theorized). Restricted to tail positions, it lets
+    // `a && !b`, `!a && !b`, etc. parse -- not just `!a && b`, which the
+    // leading-unary `expression` alternative below already covers.
+    _chain_term: ($) => seq(optional(alias($._prefixUnaryOperator, $.operator)), $._rhs_expression),
+
     // Deliberately excludes $.ternary_expression itself (and the statement-
     // like forms below) so a bare, unparenthesized ternary can't be used as
     // another ternary's condition -- `a ? b : c` must be wrapped in parens
@@ -227,7 +238,22 @@ const haxe_grammar = {
         $.switch_expression,
         $.ternary_expression,
         // simple expression, or chained.
-        seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
+        seq($._rhs_expression, repeat(seq($.operator, $._chain_term))),
+        // Same chain, but with a leading prefix-unary term (`!x && y`,
+        // `-x + y`, etc.) -- requires repeat1 (at least one more operator/
+        // term after the head) so this alternative is never reachable for a
+        // solo unary term like `!x` alone; that continues to go exclusively
+        // through $._unaryExpression above. Without that exclusivity this
+        // would create a second, ambiguous derivation for every solo unary
+        // expression. $._unaryExpression's prefix-only reach (never chained)
+        // meant `!x && y` and similar always failed outright, even though
+        // it's extremely common real-world code (818 files in this depot
+        // use this shape).
+        seq(
+          alias($._prefixUnaryOperator, $.operator),
+          $._rhs_expression,
+          repeat1(seq($.operator, $._chain_term)),
+        ),
         seq('return', optional($._rhs_expression)),
         seq('untyped', $._rhs_expression),
         'break',

--- a/grammar.js
+++ b/grammar.js
@@ -254,8 +254,73 @@ const haxe_grammar = {
           $._rhs_expression,
           repeat1(seq($.operator, $._chain_term)),
         ),
-        seq('return', optional($._rhs_expression)),
-        seq('untyped', $._rhs_expression),
+        // $.subscript_expression as a chain HEAD -- `x[i] = y;`,
+        // `x[i] * y`, etc. $.subscript_expression was only ever a complete,
+        // standalone `expression` on its own (e.g. `x[i];` alone), never
+        // one term of a longer chain, so any assignment or arithmetic
+        // involving an array/map element on the left failed outright.
+        // Extremely common (e.g. `mPieces[idx] = null;`,
+        // `sPeerMap[arg] = sharedName;`, `kBonusWinCredits[i] * mult`).
+        // repeat1-gated for the same reason as the leading-unary
+        // alternative above: a solo `x[i]` alone must still go through
+        // the plain $.subscript_expression choice, not this one.
+        seq($.subscript_expression, repeat1(seq($.operator, $._chain_term))),
+        // A postfix-unary term (`i--`, `i++`) as a chain HEAD -- `i-- > 0`,
+        // common in `while (i-- > 0)` loops. The leading-unary alternative
+        // above only covers a PREFIX unary head (`!x && y`); postfix was
+        // still only reachable as the entire standalone $._unaryExpression,
+        // never chained with a further operator. Same repeat1 gating and
+        // same rationale as the leading-unary alternative.
+        seq(
+          $._rhs_expression,
+          alias($._postfixUnaryOperator, $.operator),
+          repeat1(seq($.operator, $._chain_term)),
+        ),
+        // `return`/`untyped` previously only took a single bare
+        // $._rhs_expression, not a chain -- so `return a == b;` or
+        // `return a = b;` (assign-and-return, common in this depot's
+        // property setters, e.g. `return mKenoCardModel = kenoCardModel;`)
+        // had no valid derivation covering the whole span, and would
+        // hard-error. This was actually a PRE-EXISTING gap masked by a
+        // separate bug: before the _unaryExpression operator-set fix
+        // elsewhere in this fork's history, `a ==`/`a =` could silently
+        // (and incorrectly) match as _unaryExpression's postfix form
+        // (generic $.operator misread as a bogus postfix unary op),
+        // giving `return` an _rhs_expression-shaped path to latch onto by
+        // accident. Fixing that bug correctly closed off the accidental
+        // path here too, surfacing this as a hard ERROR instead of a
+        // silent misparse -- found via a depot-wide sweep combining this
+        // fork's fixes, not caught by any single fix's own testing.
+        // Broadened to accept the same chain shapes -- plain and
+        // leading-unary -- that a bare (non-`return`) expression already
+        // supports, plus a bare subscript return value (`return arr[i];`,
+        // also common) which $._rhs_expression doesn't cover either.
+        seq(
+          'return',
+          optional(
+            choice(
+              seq($._rhs_expression, repeat(seq($.operator, $._chain_term))),
+              seq(
+                alias($._prefixUnaryOperator, $.operator),
+                $._rhs_expression,
+                repeat(seq($.operator, $._chain_term)),
+              ),
+              $.subscript_expression,
+            ),
+          ),
+        ),
+        seq(
+          'untyped',
+          choice(
+            seq($._rhs_expression, repeat(seq($.operator, $._chain_term))),
+            $.subscript_expression,
+            seq(
+              alias($._prefixUnaryOperator, $.operator),
+              $._rhs_expression,
+              repeat(seq($.operator, $._chain_term)),
+            ),
+          ),
+        ),
         'break',
         'continue',
       ),

--- a/test/corpus/binary_operators.txt
+++ b/test/corpus/binary_operators.txt
@@ -59,3 +59,104 @@ var x = 1 + y;
     (integer) (operator) (identifier)
   )
 )
+
+
+
+===================
+less than comparison
+===================
+
+var x = a < b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+greater than comparison
+===================
+
+var x = a > b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+less than or equal comparison
+===================
+
+var x = a <= b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+greater than or equal comparison
+===================
+
+var x = a >= b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+equality comparison
+===================
+
+var x = a == b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+inequality comparison
+===================
+
+var x = a != b;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+less-than comparison does not get mistaken for a generic call's type params
+===================
+
+var x = a < b;
+var y = Vector<Float>(x);
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+  (variable_declaration (identifier) (operator)
+    (call_expression
+      (identifier)
+      (type_params (type (identifier)))
+      (identifier)
+    )
+  )
+)

--- a/test/corpus/expression_chain_completeness.txt
+++ b/test/corpus/expression_chain_completeness.txt
@@ -1,0 +1,113 @@
+===================
+return with a comparison chain
+===================
+
+class F {
+  function b() {
+    return a == b;
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block (identifier) (operator) (identifier))
+      )
+    )
+  )
+)
+
+===================
+return with an assign-and-return chain
+===================
+
+class F {
+  function b() {
+    return a = b;
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block (identifier) (operator) (identifier))
+      )
+    )
+  )
+)
+
+===================
+return with a bare subscript, no operator
+===================
+
+class F {
+  function b() {
+    return arr[i];
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block (subscript_expression (identifier) (identifier)))
+      )
+    )
+  )
+)
+
+===================
+subscript_expression as the head of an assignment chain
+===================
+
+class F {
+  function b() {
+    arr[i] = value;
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (subscript_expression (identifier) (identifier))
+          (operator)
+          (identifier)
+        )
+      )
+    )
+  )
+)
+
+===================
+postfix unary as the head of a comparison chain
+===================
+
+class F {
+  function b() {
+    i-- > 0;
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block (identifier) (operator) (operator) (integer))
+      )
+    )
+  )
+)

--- a/test/corpus/ternary.txt
+++ b/test/corpus/ternary.txt
@@ -1,0 +1,106 @@
+===================
+simple ternary
+===================
+
+var x = a ? b : c;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+ternary with comparison condition, greater than
+===================
+
+var x = a > b ? c : d;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+ternary with comparison condition, less than
+===================
+
+var x = a < b ? c : d;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
+nested ternary is right-associative
+===================
+
+var x = a ? b : c ? d : e;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (ternary_expression
+        (identifier)
+        (identifier)
+        (identifier)
+      )
+    )
+  )
+)
+
+===================
+ternary as a call argument
+===================
+
+foo(a ? b : c);
+
+---
+
+(module
+  (call_expression
+    (identifier)
+    (ternary_expression
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)

--- a/test/corpus/ternary.txt
+++ b/test/corpus/ternary.txt
@@ -63,6 +63,28 @@ var x = a < b ? c : d;
 )
 
 ===================
+ternary with comparison condition in parens does not split the comparison off
+===================
+
+var x = (width < height ? width : height);
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier)
+      (operator)
+      (identifier)
+      (identifier)
+      (identifier)
+    )
+  )
+)
+
+===================
 nested ternary is right-associative
 ===================
 

--- a/test/corpus/unary_operations.txt
+++ b/test/corpus/unary_operations.txt
@@ -159,3 +159,81 @@ class main {
     )
   )
 )
+
+===================
+logical not unop as the head of a binary operator chain
+===================
+
+class main {
+  function test() {
+    if (!x && y) {}
+  }
+}
+
+---
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (operator) (identifier) (operator) (identifier)
+            (block)
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+logical not unop as the tail of a binary operator chain
+===================
+
+class main {
+  function test() {
+    if (x && !y) {}
+  }
+}
+
+---
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (identifier) (operator) (operator) (identifier)
+            (block)
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+logical not unop as both the head and the tail of a binary operator chain
+===================
+
+class main {
+  function test() {
+    if (!x && !y) {}
+  }
+}
+
+---
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (operator) (identifier) (operator) (operator) (identifier)
+            (block)
+          )
+        )
+      )
+    )
+  )
+)


### PR DESCRIPTION
Depends on #72 (`fix/unary-in-binary-chain`) -- this branch is based on its tip because these fixes complete the same chain mechanism it introduced (`$._chain_term`).

Found via a codebase-wide sweep while combining every open fix in this batch for local testing -- none of the individual fixes exercised these exact shapes, so nothing caught it until everything was combined and swept together. (Illustrative examples below use generic names, not real source.)

**Three related gaps, all in `expression`'s chain mechanism:**

- `return`/`untyped` only ever took a single bare `$._rhs_expression`, not a chain, so `return a == b;` or `return a = b;` (assign-and-return, a common property-setter idiom, e.g. `return field = value;`) had no valid derivation covering the whole span and hard-errored. Also added a bare `$.subscript_expression` alternative (`return arr[i];`), which `$._rhs_expression` doesn't cover either.
- `$.subscript_expression` was only ever a complete, standalone `expression` on its own (`x[i];` alone) -- never one term of a longer chain, so `x[i] = y;` and `x[i] * y` failed outright. A very common shape: assigning to or computing against an array/map element.
- A postfix-unary term (`i--`, `i++`) could only be the entire standalone `$._unaryExpression`, never chained with a further operator -- so `i-- > 0` (as in `while (i-- > 0) {...}`, a common loop idiom) failed. The leading-unary chain alternative from #72 only covers a PREFIX unary head (`!x && y`); this adds the postfix-unary-head counterpart with the same `repeat1` gating and rationale.

**Why these went unnoticed until now:** all three are pre-existing gaps, not newly introduced -- masked by a bug this fork already fixed (restricting `$._unaryExpression`'s operator set to the real prefix/postfix sets instead of the fully generic `$.operator`, in an earlier PR). Before that fix, `a ==` could silently (and incorrectly) match as `$._unaryExpression`'s postfix form, treating `==` as a bogus postfix unary operator -- which happened to give `return`/subscript/postfix-head expressions an accidental path to latch onto. Fixing that bug correctly closed off the accidental path, which is what surfaced these three as hard `ERROR`s instead of silent misparses.

**Verified:** full corpus suite 193/193 (5 new regression tests: return with a comparison chain, return with an assign-and-return chain, return with a bare subscript, subscript_expression as an assignment chain head, and postfix-unary as a comparison chain head).
