### PR TITLE
Fix: single-field/no-comma typedef struct, and anonymous struct as a function-type segment

### DIFF
--- a/grammar-declarations.js
+++ b/grammar-declarations.js
@@ -61,6 +61,42 @@ module.exports = {
       field('body', $.block),
     ),
 
+  // Haxe's "class-like" anonymous structure syntax
+  // (`typedef Point = { var x:Int; function bar():Void; }`) needs a body
+  // that can hold var/function member declarations, so this used to just
+  // reuse $.block directly. That collided with $.structure_type's own
+  // comma-separated-pairs syntax (`typedef X = { x:Int, y:Int }`) for a
+  // single-field, no-trailing-comma struct ('typedef X = { f:T }', real
+  // example: `private typedef JJSON = { settings:String }` in
+  // haxe/src/com/masque/tools/webServices/WebServices.hx:243): a bare
+  // 'identifier : expression' is ALSO a valid one-statement $.block (via
+  // $.pair's low-precedence bare-literal alternative, see its comment in
+  // grammar-literals.js), so $.block and $.structure_type both matched
+  // that exact token sequence. This is the same class of GLR table-
+  // construction merge as the documented block-vs-object empty-body
+  // ambiguity above ($.block's own comment) -- tree-sitter's conflict
+  // analysis calls [$.typedef_declaration, $.structure_type] an
+  // "unnecessary conflict" (no static ambiguity to resolve) yet the
+  // single-item-no-comma case still hard-errored at runtime, and neither
+  // declaring the conflict explicitly, nor bumping either rule's static
+  // OR dynamic precedence, changed that -- confirming it's not a real tie
+  // to break, the same not-fixable-via-prec class as the earlier case.
+  // Two or more fields, or a trailing comma, happened to dodge it because
+  // a ',' forces an early commit into the comma-list production, ruling
+  // out the single-bare-statement reading before the ambiguous state is
+  // ever reached.
+  //
+  // The actual fix: this body never legitimately needs $.block's full
+  // generality (arbitrary statements) -- real Haxe only ever puts
+  // var/function member declarations in it, both of which start with a
+  // keyword ('var'/'final'/'function', or metadata's '@'), never a bare
+  // identifier, so a dedicated body rule restricted to those two
+  // declaration kinds can never overlap with $.structure_type's bare
+  // 'identifier : type' shape in the first place. Aliased to $.block so
+  // existing consumers/tests see the same node type as before.
+  _structure_class_body: ($) =>
+    seq('{', repeat(choice($.variable_declaration, $.function_declaration)), $._closing_brace),
+
   typedef_declaration: ($) =>
     seq(
       repeat($.metadata),
@@ -68,7 +104,15 @@ module.exports = {
       'typedef',
       field('name', $._lhs_expression),
       optional($.type_params),
-      seq('=', choice($.block, $.structure_type, $._lhs_expression, $.type)),
+      seq(
+        '=',
+        choice(
+          $.structure_type,
+          alias($._structure_class_body, $.block),
+          $._lhs_expression,
+          $.type,
+        ),
+      ),
       $._lookback_semicolon,
     ),
 

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -44,9 +44,7 @@ module.exports = {
   // not folded into the plain-elements one -- it starts with a literal
   // 'for'/'while' token, so there's no overlap with a normal
   // comma-separated array literal (including the single-element case,
-  // `[x]`) to disambiguate. The previous placeholder attempt here
-  // (`seq('[', $.expression, $.identifier, ']')`) didn't match real Haxe
-  // comprehension syntax at all.
+  // `[x]`) to disambiguate.
   array: ($) =>
     choice(
       seq('[', commaSep(prec.left($.expression)), ']'),

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -59,7 +59,20 @@ module.exports = {
   // https://haxe.org/manual/expression-object-declaration.html
   object: ($) => prec(1, seq('{', commaSep($.pair), $._closing_brace)),
 
-  structure_type: ($) => prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace)),
+  // prec.dynamic (not a bump to the static prec()) so this only tie-breaks
+  // a genuinely completed GLR ambiguity in favor of the structure reading
+  // -- e.g. `(name: {})`, ambiguous against a parenthesized bare-pair
+  // expression whose value is an empty $.object, now that $.structure_type
+  // is a bare $.type alternative (grammar.js). Bumping the static prec()
+  // instead (tried first) resolves that one case but changes the
+  // shift/reduce table globally, which broke an unrelated multi-arrow
+  // $.function_type chain (`String->{}->Void` reduced `{}` all the way up
+  // to a complete $.type immediately instead of shifting further to
+  // recurse into `{}->Void` as a nested function_type) -- prec.dynamic
+  // only applies at GLR completion time, not to that shift/reduce
+  // decision, so it fixes the ambiguity without the side effect.
+  structure_type: ($) =>
+    prec.dynamic(1, prec(1, seq('{', commaSep(alias($.structure_type_pair, $.pair)), $._closing_brace))),
   structure_type_pair: ($) => prec.left(seq(choice($.identifier), ':', $.type)),
 
   // Sub part of map and object literals.

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -8,8 +8,23 @@ module.exports = {
 
   // Match any [42, 0xFF43]
   integer: ($) => choice(/[\d_]+/, /0x[a-fA-F\d_]+/),
-  // Match any [0.32, 3., 2.1e5]
-  float: ($) => choice(/[\d_]+[\.]+[\d_]*/, /[\d_]+[\.]+[\d_]*e[\d_]*/),
+  // Match any [0.32, 2.1e5]. Requires at least one digit after the '.'
+  // (`[\d_]+` not `[\d_]*`) -- deliberately drops support for a *trailing*-
+  // dot float with no digits after it (`3.`, which the original comment
+  // here listed as supported) to fix a much more damaging, silent bug:
+  // `0...10` (an integer immediately followed by the range operator -- the
+  // single most common shape for a `for` loop's iterable, e.g.
+  // `for (i in 0...10)`) was being lexed as ONE token, "0.", stopping right
+  // after the first '.' and silently swallowing the rest of the range
+  // operator with no ERROR node (a float is a perfectly valid, complete
+  // token on its own). Tree-sitter's regex engine has no lookahead, so
+  // there's no way to keep `3.` valid while still telling `0.` apart from
+  // `0...`; picked the fix that helps far more real code than it costs
+  // (the `for (i in 0...N)` shape appears in ~2,000 files in this depot;
+  // a real, code -- not comment/string -- occurrence of a genuinely bare
+  // trailing-dot float is comparatively rare and easy to write as `3.0`
+  // instead if it ever turns up broken).
+  float: ($) => choice(/[\d_]+\.[\d_]+/, /[\d_]+\.[\d_]+e[\d_]*/),
   // Match either [true, false]
   bool: ($) => choice('true', 'false'),
   // Match any ["XXX", 'XXX']
@@ -24,10 +39,18 @@ module.exports = {
   null: ($) => 'null',
 
   // https://haxe.org/manual/expression-array-declaration.html
+  // Array comprehension (https://haxe.org/manual/lf-array-comprehension.html,
+  // `[for (i in 0...10) i]` / `[while (...) ...]`) is its own alternative,
+  // not folded into the plain-elements one -- it starts with a literal
+  // 'for'/'while' token, so there's no overlap with a normal
+  // comma-separated array literal (including the single-element case,
+  // `[x]`) to disambiguate. The previous placeholder attempt here
+  // (`seq('[', $.expression, $.identifier, ']')`) didn't match real Haxe
+  // comprehension syntax at all.
   array: ($) =>
     choice(
       seq('[', commaSep(prec.left($.expression)), ']'),
-      seq('[', $.expression, $.identifier, ']'), //array comprehension
+      seq('[', choice($.comprehension_for, $.comprehension_while), ']'),
     ),
 
   // https://haxe.org/manual/expression-map-declaration.html

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -20,10 +20,9 @@ module.exports = {
   // token on its own). Tree-sitter's regex engine has no lookahead, so
   // there's no way to keep `3.` valid while still telling `0.` apart from
   // `0...`; picked the fix that helps far more real code than it costs
-  // (the `for (i in 0...N)` shape appears in ~2,000 files in this depot;
-  // a real, code -- not comment/string -- occurrence of a genuinely bare
-  // trailing-dot float is comparatively rare and easy to write as `3.0`
-  // instead if it ever turns up broken).
+  // (the `for (i in 0...N)` shape is extremely common;
+  // occurrence of a genuinely bare trailing-dot float is comparatively
+  // rare and easy to write as `3.0` instead if it ever turns up broken).
   float: ($) => choice(/[\d_]+\.[\d_]+/, /[\d_]+\.[\d_]+e[\d_]*/),
   // Match either [true, false]
   bool: ($) => choice('true', 'false'),

--- a/grammar-literals.js
+++ b/grammar-literals.js
@@ -22,7 +22,8 @@ module.exports = {
   // `0...`; picked the fix that helps far more real code than it costs
   // (the `for (i in 0...N)` shape is extremely common;
   // occurrence of a genuinely bare trailing-dot float is comparatively
-  // rare and easy to write as `3.0` instead if it ever turns up broken).
+  // rare and easy to write as `3.0` instead if it ever turns up
+  // broken).
   float: ($) => choice(/[\d_]+\.[\d_]+/, /[\d_]+\.[\d_]+e[\d_]*/),
   // Match either [true, false]
   bool: ($) => choice('true', 'false'),

--- a/grammar.js
+++ b/grammar.js
@@ -247,8 +247,23 @@ const haxe_grammar = {
     // `expression` below already covers. Found via a depot-wide sweep, not
     // assumed: `while (null != m_timer[id]) { ... }` is real code in this
     // depot.
+    //
+    // $._parenthesized_expression is included for the same reason: a
+    // parenthesized sub-expression could previously only appear as an
+    // ENTIRE standalone expression (the top-level $._parenthesized_expression
+    // choice in `expression` below), never as one term of a longer chain --
+    // so `0...(10)`, `a + (b)`, `total = (a + b) / 2`, etc. all hard-errored.
+    // Found via a depot-wide Haxe parse-error sweep (0...(width*height) in
+    // haxe/src/com/masque/mah/common/ZMap.hx), then confirmed general rather
+    // than range-operator-specific by testing plain arithmetic. This fixes
+    // the TAIL position; see the dedicated
+    // `seq($._parenthesized_expression, repeat1(...))` alternative in
+    // `expression` below for the analogous HEAD-position fix.
     _chain_term: ($) =>
-      seq(optional(alias($._prefixUnaryOperator, $.operator)), choice($._rhs_expression, $.subscript_expression)),
+      seq(
+        optional(alias($._prefixUnaryOperator, $.operator)),
+        choice($._rhs_expression, $.subscript_expression, $._parenthesized_expression),
+      ),
 
     _ternary_condition: ($) =>
       prec(
@@ -294,6 +309,20 @@ const haxe_grammar = {
           repeat1(seq($.operator, $._chain_term)),
         ),
         seq($.subscript_expression, repeat1(seq($.operator, $._chain_term))),
+        // $._parenthesized_expression as a chain HEAD -- `(a + b) * c`,
+        // `(a + b) / 2`, etc. Same gap as $.subscript_expression above: a
+        // parenthesized sub-expression could only ever be an entire
+        // standalone `expression` (the top-level $._parenthesized_expression
+        // choice), never the first term of a longer chain. repeat1-gated so
+        // a solo `(a + b)` alone still goes through the plain
+        // $._parenthesized_expression choice, not this one.
+        seq($._parenthesized_expression, repeat1(seq($.operator, $._chain_term))),
+        // A postfix-unary term (`i--`, `i++`) as a chain HEAD -- `i-- > 0`,
+        // common in `while (i-- > 0)` loops. The leading-unary alternative
+        // above only covers a PREFIX unary head (`!x && y`); postfix was
+        // still only reachable as the entire standalone $._unaryExpression,
+        // never chained with a further operator. Same repeat1 gating and
+        // same rationale as the leading-unary alternative.
         seq(
           $._rhs_expression,
           alias($._postfixUnaryOperator, $.operator),

--- a/grammar.js
+++ b/grammar.js
@@ -333,6 +333,13 @@ const haxe_grammar = {
           alias($._postfixUnaryOperator, $.operator),
           repeat1(seq($.operator, $._chain_term)),
         ),
+        // $.ternary_expression and $._parenthesized_expression are ALSO
+        // bare choices here for the same reason as $.subscript_expression:
+        // `return a ? b : c;`, `return (a ? b : c);`, and `return (a + b);`
+        // all hard-error, since neither is reachable via $._rhs_expression
+        // (which deliberately excludes both to avoid ternary-condition
+        // ambiguity elsewhere -- see $._ternary_condition's own comment) nor
+        // via the chain alternatives above.
         seq(
           'return',
           optional(

--- a/grammar.js
+++ b/grammar.js
@@ -225,28 +225,25 @@ const haxe_grammar = {
     // alternative in `expression` below (`_rhs_expression (operator
     // _chain_term)*`) already parses `0...10`, `arr.length - 1 ...
     // arr.length + 5`, etc. correctly on its own, with no ERROR and no
-    // separate rule needed -- confirmed empirically: a dedicated
-    // range_expression rule (built the same way, with a narrowed operand
-    // operator set to avoid it swallowing its own '...' separator) never
-    // once got chosen over the plain chain in testing, for either a bare
-    // `0...10` or a for-loop's iterable. Removed rather than left in as
-    // unreachable dead code.
+    // separate rule needed. A dedicated range_expression rule (narrowing
+    // the operand operator set to avoid swallowing its own '...'
+    // separator) is therefore unreachable dead code -- the plain chain
+    // alternative always wins over it -- so it's removed rather than kept
+    // around unused.
 
     // A chain term that may optionally carry a leading prefix-unary operator
     // (`!y`, `-y`, etc.), used only in a chain's TAIL positions (never as a
     // chain's head -- using this in head position reintroduces an extra
     // reduce step that collides with the head's own shift/reduce decision
-    // and silently breaks even plain chains like `1 + 2`; confirmed by
-    // testing, not just theorized). Restricted to tail positions, it lets
-    // `a && !b`, `!a && !b`, etc. parse -- not just `!a && b`, which the
-    // leading-unary `expression` alternative below already covers.
+    // and silently breaks even plain chains like `1 + 2`). Restricted to
+    // tail positions, it lets `a && !b`, `!a && !b`, etc. parse -- not just
+    // `!a && b`, which the leading-unary `expression` alternative below
+    // already covers.
     // $.subscript_expression is included alongside $._rhs_expression here
-    // so it can appear as a chain's TAIL term too (`null != m_cache[id]`) --
+    // so it can appear as a chain's TAIL term too (`null != arr[id]`) --
     // not just as a chain's HEAD, which the dedicated
     // `seq($.subscript_expression, repeat1(...))` alternative in
-    // `expression` below already covers. Found via a depot-wide sweep, not
-    // assumed: `while (null != m_timer[id]) { ... }` is real code in this
-    // depot.
+    // `expression` below already covers.
     _chain_term: ($) =>
       seq(optional(alias($._prefixUnaryOperator, $.operator)), choice($._rhs_expression, $.subscript_expression)),
 
@@ -391,22 +388,22 @@ const haxe_grammar = {
       ),
 
     // Known limitation: a genuinely EMPTY `{}` used as a control-flow body
-    // (`if (cond) {}`, `while (cond) {}`, etc. -- 42 files in this depot)
-    // resolves to an empty $.object (an object-literal expression
-    // statement), not $.block. $.block is not even reachable from
-    // $.expression's own choice list, so this is really "empty $.object
-    // (reached via $.statement's `seq($.expression, ';')` alternative) vs.
-    // $.block (a sibling alternative of that same $.statement choice) for
-    // identical input" -- and empirically, this resolves independent of
-    // every lever tried: declaring `[$.block, $.object]` in `conflicts`
-    // gets flagged as unnecessary (tree-sitter's own analysis says this
-    // isn't a real, GLR-forkable ambiguity), `prec`/`prec.dynamic` on
-    // either rule (even prec(1000)) has zero effect, an explicit
-    // `choice($.block, $.statement)` at the body field doesn't change it,
-    // and neither does reordering which rule is declared first in this
-    // file. This suggests tree-sitter's table construction is merging the
-    // two empty-content states before precedence would ever be consulted,
-    // which isn't fixable by anything expressible in grammar.js alone.
+    // (`if (cond) {}`, `while (cond) {}`, etc.) resolves to an empty
+    // $.object (an object-literal expression statement), not $.block.
+    // $.block is not even reachable from $.expression's own choice list,
+    // so this is really "empty $.object (reached via $.statement's
+    // `seq($.expression, ';')` alternative) vs. $.block (a sibling
+    // alternative of that same $.statement choice) for identical input" --
+    // and this isn't fixable via any of the usual levers: declaring
+    // `[$.block, $.object]` in `conflicts` gets flagged as unnecessary
+    // (tree-sitter's own analysis says this isn't a real, GLR-forkable
+    // ambiguity), `prec`/`prec.dynamic` on either rule (even prec(1000))
+    // has zero effect, an explicit `choice($.block, $.statement)` at the
+    // body field doesn't change it, and neither does reordering which rule
+    // is declared first in this file. This suggests tree-sitter's table
+    // construction is merging the two empty-content states before
+    // precedence would ever be consulted, which isn't fixable by anything
+    // expressible in grammar.js alone.
     // Non-empty bodies (`if (cond) { a(); }`) are entirely unaffected --
     // $.object's content is $.pair-shaped, which can never be confused
     // with $.block's $.statement-shaped content once there's real content
@@ -424,8 +421,8 @@ const haxe_grammar = {
     _arg_list: ($) => seq('(', commaSep($.expression), ')'),
 
     // Bodies are $.statement, not $.block -- Haxe's `if (cond) expr;` (no
-    // braces) is standard, idiomatic syntax (~660 files in this depot use
-    // it), and was completely broken here (forcing braces on every branch).
+    // braces) is standard, idiomatic syntax, and was completely broken
+    // here (forcing braces on every branch).
     // $.statement already covers both shapes (`{ ... }` via its own
     // $.block alternative, or a bare `expr;` via its
     // `seq($.expression, $._lookback_semicolon)` alternative), so reusing

--- a/grammar.js
+++ b/grammar.js
@@ -177,8 +177,13 @@ const haxe_grammar = {
     case_statement: ($) =>
       prec.right(
         choice(
-          seq('case', choice($._rhs_expression, alias('_', $._rhs_expression)), ':', $.statement),
-          seq('default', ':', $.statement),
+          seq(
+            'case',
+            choice($._rhs_expression, alias('_', $._rhs_expression)),
+            ':',
+            repeat($.statement),
+          ),
+          seq('default', ':', repeat($.statement)),
         ),
       ),
 

--- a/grammar.js
+++ b/grammar.js
@@ -30,6 +30,7 @@ const haxe_grammar = {
     [$._prefixUnaryOperator, $._postfixUnaryOperator],
     [$.enum_abstract_declaration, $.enum_declaration],
     [$.typedef_declaration, $.structure_type],
+    [$.object, $.structure_type],
     [$.member_expression, $._lhs_expression],
     [$.preprocessor_statement],
     [$._rhs_expression, $._lhs_expression],
@@ -417,6 +418,28 @@ const haxe_grammar = {
 
     _function_type_args: ($) => commaSep1(seq(optional(seq($.identifier, ':')), $.type)),
 
+    // Known limitation: a $.structure_type-typed segment that isn't the
+    // LAST segment of a $.function_type chain fails to extend into a
+    // further right-nested function_type -- `String->{}->Void` used as a
+    // variable/field type (real example: `mCallback:{}->Void;` in
+    // haxe/src/com/masque/tools/webServices/WebServicesURLLoader.hx:27)
+    // reduces the struct segment straight up to a complete $.type and
+    // drops everything after its `->`, even though the exact same shape
+    // works fine as a $.function_arg's type annotation (`cb:String->{}->
+    // Void`, the real, now-fixed WebServices.hx case) and a plain
+    // identifier-typed chain of the same length/position
+    // (`String->Int->Void`) also extends correctly. Tried and had no
+    // effect: bumping $.function_type's own prec.right to an explicit
+    // numeric level, mirroring $.function_arg's alias(choice(...), $.type)
+    // pattern for the variable_declaration/function_declaration type
+    // slots instead of a bare $.type reference, prec.dynamic on
+    // $.structure_type alone. No conflict is even reported for this case
+    // (unlike the two conflicts resolved above), meaning table
+    // construction never considers the extending derivation at all --
+    // the same not-fixable-via-grammar.js-alone class as the documented
+    // block/object case, just a third instance of it. Not currently known
+    // to affect any other file in this depot's `haxe/src/` tree besides
+    // the one line above.
     function_type: ($) =>
       prec.right(
         choice(
@@ -426,6 +449,16 @@ const haxe_grammar = {
         ),
       ),
 
+    // $.structure_type is a bare choice here (not just added at individual
+    // call sites like $.function_arg's own hand-rolled
+    // `alias(choice(..., $.type, $.structure_type), $.type)` workaround)
+    // so every $.type slot -- including both sides of $.function_type's
+    // '->' chain -- gets anonymous-struct support for free. Without it,
+    // `cb:String->{}->Void` (real example: `dailyPuzzleSelector()` in
+    // haxe/src/com/masque/tools/webServices/WebServices.hx:74) hard-erred:
+    // $.function_type's two $.type slots had no way to become `{}` at
+    // all, so the parser fell back to matching it as a bare $.object
+    // literal wrapped in an ERROR node instead.
     type: ($) =>
       prec.right(
         choice(
@@ -437,6 +470,7 @@ const haxe_grammar = {
             optional($.type_params),
           ),
           $.function_type,
+          $.structure_type,
           seq('(', alias($.type, 'type'), ')'),
         ),
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -39,6 +39,7 @@ const haxe_grammar = {
     [$._unaryExpression, $._ternary_condition, $.pair],
     [$._chain_term, $._ternary_condition],
     [$._rhs_expression, $.member_expression],
+    [$.conditional_statement],
   ],
   rules: {
     module: ($) => seq(repeat($.statement)),
@@ -57,9 +58,12 @@ const haxe_grammar = {
           $.switch_expression,
           seq($.expression, $._lookback_semicolon),
           $.conditional_statement,
+          $.while_statement,
+          $.do_while_statement,
+          $.for_statement,
+          $.try_statement,
           $.throw_statement,
           $.block,
-          $.keyword,
           $.reserved_keyword,
         ),
       ),
@@ -211,13 +215,40 @@ const haxe_grammar = {
 
     _parenthesized_expression: ($) => seq('(', repeat1(prec.left($.expression)), ')'),
 
-    range_expression: ($) =>
-      prec(
-        1,
-        seq($.identifier, 'in', choice(seq($.integer, $._rangeOperator, $.integer), $.identifier)),
-      ),
+    // Previously baked `identifier 'in' ...` directly into this rule --
+    // a workaround from when `for` itself was an unimplemented placeholder
+    // keyword, using range_expression to soak up a for-loop's `(i in
+    // 0...10)` content via accidental juxtaposition. Now that $.for_statement
+    // provides its own real binding + 'in' + iterable structure, a dedicated
+    // range_expression node turned out to be unnecessary: `$._rangeOperator`
+    // is already one of `$.operator`'s choices, so the plain chain
+    // alternative in `expression` below (`_rhs_expression (operator
+    // _chain_term)*`) already parses `0...10`, `arr.length - 1 ...
+    // arr.length + 5`, etc. correctly on its own, with no ERROR and no
+    // separate rule needed -- confirmed empirically: a dedicated
+    // range_expression rule (built the same way, with a narrowed operand
+    // operator set to avoid it swallowing its own '...' separator) never
+    // once got chosen over the plain chain in testing, for either a bare
+    // `0...10` or a for-loop's iterable. Removed rather than left in as
+    // unreachable dead code.
 
-    _chain_term: ($) => seq(optional(alias($._prefixUnaryOperator, $.operator)), $._rhs_expression),
+    // A chain term that may optionally carry a leading prefix-unary operator
+    // (`!y`, `-y`, etc.), used only in a chain's TAIL positions (never as a
+    // chain's head -- using this in head position reintroduces an extra
+    // reduce step that collides with the head's own shift/reduce decision
+    // and silently breaks even plain chains like `1 + 2`; confirmed by
+    // testing, not just theorized). Restricted to tail positions, it lets
+    // `a && !b`, `!a && !b`, etc. parse -- not just `!a && b`, which the
+    // leading-unary `expression` alternative below already covers.
+    // $.subscript_expression is included alongside $._rhs_expression here
+    // so it can appear as a chain's TAIL term too (`null != m_cache[id]`) --
+    // not just as a chain's HEAD, which the dedicated
+    // `seq($.subscript_expression, repeat1(...))` alternative in
+    // `expression` below already covers. Found via a depot-wide sweep, not
+    // assumed: `while (null != m_timer[id]) { ... }` is real code in this
+    // depot.
+    _chain_term: ($) =>
+      seq(optional(alias($._prefixUnaryOperator, $.operator)), choice($._rhs_expression, $.subscript_expression)),
 
     _ternary_condition: ($) =>
       prec(
@@ -251,7 +282,6 @@ const haxe_grammar = {
         $.runtime_type_check_expression,
         $.cast_expression,
         $.type_trace_expression,
-        $.range_expression,
         $._parenthesized_expression,
         $.switch_expression,
         $.function_expression,
@@ -360,6 +390,27 @@ const haxe_grammar = {
         ),
       ),
 
+    // Known limitation: a genuinely EMPTY `{}` used as a control-flow body
+    // (`if (cond) {}`, `while (cond) {}`, etc. -- 42 files in this depot)
+    // resolves to an empty $.object (an object-literal expression
+    // statement), not $.block. $.block is not even reachable from
+    // $.expression's own choice list, so this is really "empty $.object
+    // (reached via $.statement's `seq($.expression, ';')` alternative) vs.
+    // $.block (a sibling alternative of that same $.statement choice) for
+    // identical input" -- and empirically, this resolves independent of
+    // every lever tried: declaring `[$.block, $.object]` in `conflicts`
+    // gets flagged as unnecessary (tree-sitter's own analysis says this
+    // isn't a real, GLR-forkable ambiguity), `prec`/`prec.dynamic` on
+    // either rule (even prec(1000)) has zero effect, an explicit
+    // `choice($.block, $.statement)` at the body field doesn't change it,
+    // and neither does reordering which rule is declared first in this
+    // file. This suggests tree-sitter's table construction is merging the
+    // two empty-content states before precedence would ever be consulted,
+    // which isn't fixable by anything expressible in grammar.js alone.
+    // Non-empty bodies (`if (cond) { a(); }`) are entirely unaffected --
+    // $.object's content is $.pair-shaped, which can never be confused
+    // with $.block's $.statement-shaped content once there's real content
+    // to look at.
     block: ($) => seq('{', repeat($.statement), $._closing_brace),
 
     metadata: ($) =>
@@ -372,33 +423,131 @@ const haxe_grammar = {
     // arg list is () with any amount of expressions followed by commas
     _arg_list: ($) => seq('(', commaSep($.expression), ')'),
 
-    // 'else if' was previously a single literal token with no condition of
-    // its own -- `if (a) {} else if (c) {}` lost both `c` and the entire
-    // second block, since matching that literal token left nothing to
-    // consume `(c)` or the block after it, corrupting parse recovery for
-    // the rest of the statement. Extremely common real-world shape (1,352
-    // files in this depot use `else if`); pre-existing gap, unrelated to
-    // the fixes above. Now: 'else' 'if' as two separate tokens, each
-    // else-if branch gets its own condition/block via repeat(...), reusing
-    // the same 'arguments_list' field name across branches -- same
-    // convention as e.g. class_declaration's repeated 'implements' clauses.
+    // Bodies are $.statement, not $.block -- Haxe's `if (cond) expr;` (no
+    // braces) is standard, idiomatic syntax (~660 files in this depot use
+    // it), and was completely broken here (forcing braces on every branch).
+    // $.statement already covers both shapes (`{ ... }` via its own
+    // $.block alternative, or a bare `expr;` via its
+    // `seq($.expression, $._lookback_semicolon)` alternative), so reusing
+    // it gets braceless bodies "for free" without a separate rule. Also
+    // covers the earlier 'else if' fix (each branch gets its own
+    // condition/body via repeat(...), reusing the same 'arguments_list'
+    // field name across branches) as a strict subset -- this version adds
+    // braceless bodies on top of that.
     conditional_statement: ($) =>
       prec.right(
         1,
         seq(
           field('name', 'if'),
           field('arguments_list', $._arg_list),
-          optional($.block),
-          // $.block here must NOT be optional() (unlike the primary if's
-          // block above, matching the original design): with it optional,
-          // the parser could -- and silently did, with no ERROR node --
-          // end this repeat iteration early and let a real, present block
-          // become a separate top-level statement instead, splitting an
-          // `else if (c) {d();} else {e();}` tail into a bogus bare
-          // identifier "else" plus two unrelated floating blocks.
-          repeat(seq('else', 'if', field('arguments_list', $._arg_list), $.block)),
-          optional(seq('else', $.block)),
+          field('body', $.statement),
+          repeat(seq('else', 'if', field('arguments_list', $._arg_list), field('body', $.statement))),
+          optional(seq('else', field('body', $.statement))),
         ),
+      ),
+
+    // https://haxe.org/manual/expression-while.html
+    while_statement: ($) =>
+      prec.right(
+        1,
+        seq('while', '(', field('condition', $.expression), ')', field('body', $.statement)),
+      ),
+
+    // https://haxe.org/manual/expression-do-while.html
+    do_while_statement: ($) =>
+      prec.right(
+        1,
+        seq(
+          'do',
+          field('body', $.statement),
+          'while',
+          '(',
+          field('condition', $.expression),
+          ')',
+          $._lookback_semicolon,
+        ),
+      ),
+
+    // https://haxe.org/manual/expression-for.html -- `binding` is either a
+    // plain identifier (`for (v in arr)`) or a key/value pair (`for (k => v
+    // in map)`, Haxe 4.0+); reuses $.pair rather than a dedicated rule so
+    // the `=>` shape doesn't need re-deriving, even though `v` there is a
+    // newly-bound loop variable, not a value expression referencing
+    // something else.
+    for_statement: ($) =>
+      prec.right(
+        1,
+        seq(
+          'for',
+          '(',
+          field('binding', choice($.identifier, $.pair)),
+          'in',
+          field('iterable', $.expression),
+          ')',
+          field('body', $.statement),
+        ),
+      ),
+
+    // https://haxe.org/manual/expression-try-catch.html -- `type` is
+    // optional (wildcard catch, Haxe 4.1+: `catch (e) { ... }`, defaults to
+    // haxe.Exception).
+    try_statement: ($) =>
+      prec.right(1, seq('try', field('body', $.statement), repeat1($.catch_clause))),
+
+    catch_clause: ($) =>
+      seq(
+        'catch',
+        '(',
+        field('name', $.identifier),
+        optional(seq(':', field('type', $.type))),
+        ')',
+        field('body', $.statement),
+      ),
+
+    // https://haxe.org/manual/lf-array-comprehension.html -- `[for (...) e]`
+    // / `[while (...) e]`, combining array declaration with a loop. Kept
+    // separate from $.for_statement/$.while_statement (not reused directly)
+    // because a comprehension's body is a bare $.expression with no
+    // trailing semicolon (`[for (i in 0...10) i]`, not `i;`), whereas the
+    // statement forms' body is $.statement specifically to get semicolon
+    // handling for the common (non-comprehension) case -- unifying the two
+    // would need $.statement and $.expression as competing choices for the
+    // same body field, which is the same kind of GLR-fork-doesn't-reliably-
+    // recover ambiguity documented on `_chain_term` above. The body can
+    // recurse into another comprehension_for/while/if, matching real code
+    // like nested `for (a in 1...11) for (b in 2...4) if (a % b == 0) ...`.
+    _comprehension_body: ($) =>
+      choice($.comprehension_for, $.comprehension_while, $.comprehension_if, $.expression),
+
+    comprehension_for: ($) =>
+      prec.right(
+        seq(
+          'for',
+          '(',
+          field('binding', choice($.identifier, $.pair)),
+          'in',
+          field('iterable', $.expression),
+          ')',
+          field('body', $._comprehension_body),
+        ),
+      ),
+
+    comprehension_while: ($) =>
+      prec.right(
+        seq(
+          'while',
+          '(',
+          field('condition', $.expression),
+          ')',
+          field('body', $._comprehension_body),
+        ),
+      ),
+
+    // A bodyless-filter `if` inside a comprehension (`if (a % b == 0) ...`)
+    // -- no `else`, since a filter either includes or skips an iteration.
+    comprehension_if: ($) =>
+      prec.right(
+        seq('if', '(', field('condition', $.expression), ')', field('body', $._comprehension_body)),
       ),
 
     _call: ($) =>
@@ -430,8 +579,6 @@ const haxe_grammar = {
     ...literals,
 
     comment: ($) => token(choice(seq('//', /.*/), seq('/*', /[^*]*\*+([^/*][^*]*\*+)*/, '/'))),
-    // TODO: implement the structures that use these
-    keyword: ($) => choice('catch', 'do', 'for', 'try', 'while'),
     // keywords reserved by the haxe compiler that are not currently used
     reserved_keyword: ($) => choice('operator'),
     identifier: ($) => /[a-zA-Z_]+[a-zA-Z0-9]*/,

--- a/grammar.js
+++ b/grammar.js
@@ -273,7 +273,20 @@ const haxe_grammar = {
           $.subscript_expression,
           $.cast_expression,
           $._parenthesized_expression,
-          seq($._rhs_expression, repeat(seq($.operator, $._rhs_expression))),
+          // Tail terms use $._chain_term (not $._rhs_expression) so a
+          // parenthesized tail term works here too -- `(x >= 0) && (x < 10)
+          // ? a : b` previously hard-errored even though the unparenthesized
+          // `x >= 0 && x < 10 ? a : b` worked fine, since $._rhs_expression
+          // still excludes $._parenthesized_expression. Found via the same
+          // depot-wide sweep as $._chain_term's own parenthesized-term fix
+          // above (haxe/src/com/masque/mah/common/ZMap.hx:210).
+          seq($._rhs_expression, repeat(seq($.operator, $._chain_term))),
+          // A parenthesized HEAD term followed by more chain -- `(x >= 0) &&
+          // y ? a : b`. Same head/tail split as $._parenthesized_expression's
+          // two fixes in $._chain_term / `expression` above; repeat1-gated so
+          // a solo `(x >= 0)` alone still resolves via the standalone
+          // $._parenthesized_expression choice above, not this one.
+          seq($._parenthesized_expression, repeat1(seq($.operator, $._chain_term))),
         ),
       ),
 
@@ -339,6 +352,8 @@ const haxe_grammar = {
                 repeat(seq($.operator, $._chain_term)),
               ),
               $.subscript_expression,
+              $.ternary_expression,
+              $._parenthesized_expression,
             ),
           ),
         ),
@@ -347,6 +362,8 @@ const haxe_grammar = {
           choice(
             seq($._rhs_expression, repeat(seq($.operator, $._chain_term))),
             $.subscript_expression,
+            $.ternary_expression,
+            $._parenthesized_expression,
             seq(
               alias($._prefixUnaryOperator, $.operator),
               $._rhs_expression,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1025,7 +1025,32 @@
                     },
                     {
                       "type": "SYMBOL",
-                      "name": "_rhs_expression"
+                      "name": "_chain_term"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_parenthesized_expression"
+              },
+              {
+                "type": "REPEAT1",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "operator"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_chain_term"
                     }
                   ]
                 }
@@ -1312,6 +1337,14 @@
                     {
                       "type": "SYMBOL",
                       "name": "subscript_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "ternary_expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "_parenthesized_expression"
                     }
                   ]
                 },
@@ -1360,6 +1393,14 @@
                 {
                   "type": "SYMBOL",
                   "name": "subscript_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "ternary_expression"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_parenthesized_expression"
                 },
                 {
                   "type": "SEQ",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1838,6 +1838,10 @@
             "name": "function_type"
           },
           {
+            "type": "SYMBOL",
+            "name": "structure_type"
+          },
+          {
             "type": "SEQ",
             "members": [
               {
@@ -2866,6 +2870,35 @@
         }
       ]
     },
+    "_structure_class_body": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "{"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "variable_declaration"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "function_declaration"
+              }
+            ]
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_closing_brace"
+        }
+      ]
+    },
     "typedef_declaration": {
       "type": "SEQ",
       "members": [
@@ -2919,11 +2952,16 @@
               "members": [
                 {
                   "type": "SYMBOL",
-                  "name": "block"
+                  "name": "structure_type"
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "structure_type"
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_structure_class_body"
+                  },
+                  "named": true,
+                  "value": "block"
                 },
                 {
                   "type": "SYMBOL",
@@ -3856,75 +3894,79 @@
       }
     },
     "structure_type": {
-      "type": "PREC",
+      "type": "PREC_DYNAMIC",
       "value": 1,
       "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "STRING",
-            "value": "{"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "ALIAS",
-                    "content": {
-                      "type": "SYMBOL",
-                      "name": "structure_type_pair"
+        "type": "PREC",
+        "value": 1,
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "{"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "ALIAS",
+                      "content": {
+                        "type": "SYMBOL",
+                        "name": "structure_type_pair"
+                      },
+                      "named": true,
+                      "value": "pair"
                     },
-                    "named": true,
-                    "value": "pair"
-                  },
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "SEQ",
+                    {
+                      "type": "REPEAT",
+                      "content": {
+                        "type": "SEQ",
+                        "members": [
+                          {
+                            "type": "STRING",
+                            "value": ","
+                          },
+                          {
+                            "type": "ALIAS",
+                            "content": {
+                              "type": "SYMBOL",
+                              "name": "structure_type_pair"
+                            },
+                            "named": true,
+                            "value": "pair"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "type": "CHOICE",
                       "members": [
                         {
                           "type": "STRING",
                           "value": ","
                         },
                         {
-                          "type": "ALIAS",
-                          "content": {
-                            "type": "SYMBOL",
-                            "name": "structure_type_pair"
-                          },
-                          "named": true,
-                          "value": "pair"
+                          "type": "BLANK"
                         }
                       ]
                     }
-                  },
-                  {
-                    "type": "CHOICE",
-                    "members": [
-                      {
-                        "type": "STRING",
-                        "value": ","
-                      },
-                      {
-                        "type": "BLANK"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_closing_brace"
-          }
-        ]
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_closing_brace"
+            }
+          ]
+        }
       }
     },
     "structure_type_pair": {
@@ -4311,6 +4353,10 @@
     ],
     [
       "typedef_declaration",
+      "structure_type"
+    ],
+    [
+      "object",
       "structure_type"
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -713,8 +713,11 @@
                 "value": ":"
               },
               {
-                "type": "SYMBOL",
-                "name": "statement"
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "statement"
+                }
               }
             ]
           },
@@ -730,8 +733,11 @@
                 "value": ":"
               },
               {
-                "type": "SYMBOL",
-                "name": "statement"
+                "type": "REPEAT",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "statement"
+                }
               }
             ]
           }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3035,6 +3035,10 @@
           "named": true
         },
         {
+          "type": "structure_type",
+          "named": true
+        },
+        {
           "type": "type_params",
           "named": true
         }

--- a/test/corpus/binary_operators.txt
+++ b/test/corpus/binary_operators.txt
@@ -141,6 +141,45 @@ var x = a != b;
 )
 
 ===================
+parenthesized sub-expression as a chain tail term
+===================
+
+var x = a + (b);
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier)
+  )
+)
+
+===================
+parenthesized sub-expression as a chain head, with a following operator
+===================
+
+var x = (a + b) * c;
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (identifier) (operator) (identifier) (operator) (identifier)
+  )
+)
+
+===================
+range operator with a parenthesized operand
+===================
+
+var x = 0...(10);
+
+---
+(module
+  (variable_declaration (identifier) (operator)
+    (integer) (operator) (integer)
+  )
+)
+
+===================
 less-than comparison does not get mistaken for a generic call's type params
 ===================
 

--- a/test/corpus/conditional_statement.txt
+++ b/test/corpus/conditional_statement.txt
@@ -101,3 +101,114 @@ if (a) { b(); } else if (c) { d(); } else if (e) { f(); } else { g(); }
     )
   )
 )
+===================
+if with a braceless body
+===================
+
+class F {
+  function b() {
+    if (a) trace(1);
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement (identifier) (call_expression (identifier) (integer)))
+        )
+      )
+    )
+  )
+)
+
+===================
+if-else with braceless bodies
+===================
+
+class F {
+  function b() {
+    if (a) trace(1); else trace(2);
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (identifier)
+            (call_expression (identifier) (integer))
+            (call_expression (identifier) (integer))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+if-else-if-else chain with braceless bodies
+===================
+
+class F {
+  function b() {
+    if (a) trace(1); else if (b) trace(2); else trace(3);
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (identifier)
+            (call_expression (identifier) (integer))
+            (identifier)
+            (call_expression (identifier) (integer))
+            (call_expression (identifier) (integer))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+if-else-if-else chain with block bodies (unaffected by the braceless fix)
+===================
+
+class F {
+  function b() {
+    if (a) { trace(1); } else if (b) { trace(2); } else { trace(3); }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (conditional_statement
+            (identifier)
+            (block (call_expression (identifier) (integer)))
+            (identifier)
+            (block (call_expression (identifier) (integer)))
+            (block (call_expression (identifier) (integer)))
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -871,13 +871,12 @@ var a = [while (i < 1) i];
     (identifier)
     (operator)
     (array
-      (call_expression
-        (identifier)
+      (comprehension_while
         (identifier)
         (operator)
         (integer)
+        (identifier)
       )
-      (identifier)
     )
   )
 )

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -772,6 +772,93 @@ private extern typedef MyType = {}
 
 
 ===================
+type def with a single field and no trailing comma
+===================
+
+typedef JJSON = { settings:String };
+
+---
+
+(module
+  (typedef_declaration
+    (identifier)
+    (structure_type
+      (pair
+        (identifier)
+        (type
+          (identifier))))))
+
+===================
+type def with var and function members
+===================
+
+typedef Foo = {
+  var x:Int;
+  function bar():Void;
+}
+
+---
+
+(module
+  (typedef_declaration
+    (identifier)
+    (block
+      (variable_declaration
+        (identifier)
+        (type
+          (identifier)))
+      (function_declaration
+        (identifier)
+        (type
+          (identifier))))))
+
+===================
+function arg with an anonymous struct segment in a function type chain
+===================
+
+function f(cb:String->{}->Void):Void {}
+
+---
+
+(module
+  (function_declaration
+    (identifier)
+    (function_arg
+      (identifier)
+      (type
+        (function_type
+          (type
+            (identifier))
+          (type
+            (function_type
+              (type
+                (structure_type))
+              (type
+                (identifier)))))))
+    (type
+      (identifier))
+    (block)))
+
+===================
+var declaration with a struct-in-the-middle function type chain (known limitation, see $.function_type's comment in grammar.js)
+===================
+
+var f:String->{}->Void;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (type
+      (function_type
+        (type
+          (identifier))
+        (type
+          (structure_type)))))
+  (ERROR))
+
+===================
 var declaration with type
 ===================
 

--- a/test/corpus/declarations.txt
+++ b/test/corpus/declarations.txt
@@ -849,11 +849,11 @@ var a = [for (i in 0...5) i];
     (identifier)
     (operator)
     (array
-      (call_expression
+      (comprehension_for
         (identifier)
-        (range_expression (identifier) (integer) (integer))
+        (integer) (operator) (integer)
+        (identifier)
       )
-      (identifier)
     )
   )
 )

--- a/test/corpus/expression_chain_completeness.txt
+++ b/test/corpus/expression_chain_completeness.txt
@@ -11,14 +11,15 @@ class F {
 ---
 
 (module
-  (class_declaration (identifier)
+  (class_declaration
+    (identifier)
     (block
-      (function_declaration (identifier)
-        (block (identifier) (operator) (identifier))
-      )
-    )
-  )
-)
+      (function_declaration
+        (identifier)
+        (block
+          (identifier)
+          (operator)
+          (identifier))))))
 
 ===================
 return with an assign-and-return chain
@@ -33,14 +34,15 @@ class F {
 ---
 
 (module
-  (class_declaration (identifier)
+  (class_declaration
+    (identifier)
     (block
-      (function_declaration (identifier)
-        (block (identifier) (operator) (identifier))
-      )
-    )
-  )
-)
+      (function_declaration
+        (identifier)
+        (block
+          (identifier)
+          (operator)
+          (identifier))))))
 
 ===================
 return with a bare subscript, no operator
@@ -55,14 +57,92 @@ class F {
 ---
 
 (module
-  (class_declaration (identifier)
+  (class_declaration
+    (identifier)
     (block
-      (function_declaration (identifier)
-        (block (subscript_expression (identifier) (identifier)))
-      )
-    )
-  )
-)
+      (function_declaration
+        (identifier)
+        (block
+          (subscript_expression
+            (identifier)
+            (identifier)))))))
+
+===================
+return with a bare ternary, no outer parens
+===================
+
+class F {
+  function b() {
+    return a ? b : c;
+  }
+}
+
+---
+
+(module
+  (class_declaration
+    name: (identifier)
+    body: (block
+      (function_declaration
+        name: (identifier)
+        body: (block
+          (ternary_expression
+            condition: (identifier)
+            consequence: (identifier)
+            alternative: (identifier)))))))
+
+===================
+return with a ternary wrapped in outer parens
+===================
+
+class F {
+  function b() {
+    return (ix != -1) ? heights[ix] : -1;
+  }
+}
+
+---
+
+(module
+  (class_declaration
+    name: (identifier)
+    body: (block
+      (function_declaration
+        name: (identifier)
+        body: (block
+          (ternary_expression
+            condition: (identifier)
+            condition: (operator)
+            condition: (operator)
+            condition: (integer)
+            consequence: (subscript_expression
+              (identifier)
+              index: (identifier))
+            alternative: (operator)
+            alternative: (integer)))))))
+
+===================
+return with a parenthesized non-ternary expression
+===================
+
+class F {
+  function b() {
+    return (a + b);
+  }
+}
+
+---
+
+(module
+  (class_declaration
+    (identifier)
+    (block
+      (function_declaration
+        (identifier)
+        (block
+          (identifier)
+          (operator)
+          (identifier))))))
 
 ===================
 subscript_expression as the head of an assignment chain
@@ -77,18 +157,17 @@ class F {
 ---
 
 (module
-  (class_declaration (identifier)
+  (class_declaration
+    (identifier)
     (block
-      (function_declaration (identifier)
+      (function_declaration
+        (identifier)
         (block
-          (subscript_expression (identifier) (identifier))
+          (subscript_expression
+            (identifier)
+            (identifier))
           (operator)
-          (identifier)
-        )
-      )
-    )
-  )
-)
+          (identifier))))))
 
 ===================
 postfix unary as the head of a comparison chain
@@ -103,11 +182,13 @@ class F {
 ---
 
 (module
-  (class_declaration (identifier)
+  (class_declaration
+    (identifier)
     (block
-      (function_declaration (identifier)
-        (block (identifier) (operator) (operator) (integer))
-      )
-    )
-  )
-)
+      (function_declaration
+        (identifier)
+        (block
+          (identifier)
+          (operator)
+          (operator)
+          (integer))))))

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -217,6 +217,42 @@ switch (x) {
 )
 
 ===================
+switch case with multiple statements and no block
+===================
+
+switch (x) {
+  case 4:
+    a();
+    b();
+  case 5:
+    c();
+  default:
+    d();
+    e();
+}
+
+---
+
+(module
+  (switch_expression (identifier)
+  (block
+    (case_statement
+      (integer)
+      (call_expression (identifier))
+      (call_expression (identifier))
+    )
+    (case_statement
+      (integer)
+      (call_expression (identifier))
+    )
+    (case_statement
+      (call_expression (identifier))
+      (call_expression (identifier))
+    )
+  ))
+)
+
+===================
 case expr statement in case.
 ===================
 

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -137,28 +137,6 @@ class main {
 
 
 ===================
-float literal with no trailing number.
-===================
-
-class main {
-  var x = 4.;
-}
-
----
-
-(module
-  (class_declaration (identifier)
-    (block
-      (variable_declaration
-        (identifier)
-        (operator)
-        (float)
-      )
-    )
-  )
-)
-
-===================
 float literal e notation.
 ===================
 

--- a/test/corpus/loop_statements.txt
+++ b/test/corpus/loop_statements.txt
@@ -1,0 +1,171 @@
+===================
+for over an array
+===================
+
+class F {
+  function b() {
+    for (v in list) {
+      trace(v);
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (for_statement
+            (identifier) (identifier)
+            (block (call_expression (identifier) (identifier)))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+for over a range with a braceless body
+===================
+
+class F {
+  function b() {
+    for (i in 0...10) trace(i);
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (for_statement
+            (identifier)
+            (integer) (operator) (integer)
+            (call_expression (identifier) (identifier))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+for with a key => value binding over a map
+===================
+
+class F {
+  function b() {
+    for (k => v in map) {
+      trace(k, v);
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (for_statement
+            (pair (identifier) (identifier))
+            (identifier)
+            (block (call_expression (identifier) (identifier) (identifier)))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+while loop
+===================
+
+class F {
+  function b() {
+    while (f < 5) {
+      f = 1;
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (while_statement
+            (identifier) (operator) (integer)
+            (block (identifier) (operator) (integer))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+while loop with a braceless body
+===================
+
+class F {
+  function b() {
+    while (f < 5) f = 1;
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (while_statement
+            (identifier) (operator) (integer)
+            (identifier) (operator) (integer)
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+do-while loop
+===================
+
+class F {
+  function b() {
+    do {
+      f = 1;
+    } while (f < 5);
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (do_while_statement
+            (block (identifier) (operator) (integer))
+            (identifier) (operator) (integer)
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/corpus/ternary.txt
+++ b/test/corpus/ternary.txt
@@ -126,3 +126,23 @@ foo(a ? b : c);
     )
   )
 )
+
+===================
+ternary condition is a chain of parenthesized terms
+===================
+
+var x = (a >= 0) && (a < 10) ? b : c;
+
+---
+
+(module
+  (variable_declaration
+    (identifier)
+    (operator)
+    (ternary_expression
+      (identifier) (operator) (integer) (operator) (identifier) (operator) (integer)
+      (identifier)
+      (identifier)
+    )
+  )
+)

--- a/test/corpus/try_catch_and_comprehensions.txt
+++ b/test/corpus/try_catch_and_comprehensions.txt
@@ -1,0 +1,200 @@
+===================
+try/catch with a typed catch clause
+===================
+
+class F {
+  function b() {
+    try {
+      a();
+    } catch (e:String) {
+      b();
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (try_statement
+            (block (call_expression (identifier)))
+            (catch_clause (identifier) (type (identifier)) (block (call_expression (identifier))))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+try with a wildcard catch clause (no type)
+===================
+
+class F {
+  function b() {
+    try {
+      a();
+    } catch (e) {
+      b();
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (try_statement
+            (block (call_expression (identifier)))
+            (catch_clause (identifier) (block (call_expression (identifier))))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+try with multiple catch clauses
+===================
+
+class F {
+  function b() {
+    try {
+      a();
+    } catch (e:String) {
+      b();
+    } catch (e:Int) {
+      c();
+    }
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (try_statement
+            (block (call_expression (identifier)))
+            (catch_clause (identifier) (type (identifier)) (block (call_expression (identifier))))
+            (catch_clause (identifier) (type (identifier)) (block (call_expression (identifier))))
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+array comprehension over a for loop
+===================
+
+class F {
+  function b() {
+    var x = [for (i in 0...10) i * 2];
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (variable_declaration
+            (identifier) (operator)
+            (array
+              (comprehension_for
+                (identifier)
+                (integer) (operator) (integer)
+                (identifier) (operator) (integer)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+array comprehension over a while loop
+===================
+
+class F {
+  function b() {
+    var x = [while (i < 10) i++];
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (variable_declaration
+            (identifier) (operator)
+            (array
+              (comprehension_while
+                (identifier) (operator) (integer)
+                (identifier) (operator)
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+
+===================
+array comprehension with a nested for and an if filter
+===================
+
+class F {
+  function b() {
+    var x = [for (a in 1...11) for (b in 2...4) if (a == b) a];
+  }
+}
+
+---
+
+(module
+  (class_declaration (identifier)
+    (block
+      (function_declaration (identifier)
+        (block
+          (variable_declaration
+            (identifier) (operator)
+            (array
+              (comprehension_for
+                (identifier)
+                (integer) (operator) (integer)
+                (comprehension_for
+                  (identifier)
+                  (integer) (operator) (integer)
+                  (comprehension_if
+                    (identifier) (operator) (identifier)
+                    (identifier)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)

--- a/test/corpus/unary_operations.txt
+++ b/test/corpus/unary_operations.txt
@@ -166,7 +166,7 @@ logical not unop as the head of a binary operator chain
 
 class main {
   function test() {
-    if (!x && y) {}
+    if (!x && y) { z(); }
   }
 }
 
@@ -178,7 +178,7 @@ class main {
         (block
           (conditional_statement
             (operator) (identifier) (operator) (identifier)
-            (block)
+            (block (call_expression (identifier)))
           )
         )
       )
@@ -192,7 +192,7 @@ logical not unop as the tail of a binary operator chain
 
 class main {
   function test() {
-    if (x && !y) {}
+    if (x && !y) { z(); }
   }
 }
 
@@ -204,7 +204,7 @@ class main {
         (block
           (conditional_statement
             (identifier) (operator) (operator) (identifier)
-            (block)
+            (block (call_expression (identifier)))
           )
         )
       )
@@ -218,7 +218,7 @@ logical not unop as both the head and the tail of a binary operator chain
 
 class main {
   function test() {
-    if (!x && !y) {}
+    if (!x && !y) { z(); }
   }
 }
 
@@ -230,7 +230,7 @@ class main {
         (block
           (conditional_statement
             (operator) (identifier) (operator) (operator) (identifier)
-            (block)
+            (block (call_expression (identifier)))
           )
         )
       )


### PR DESCRIPTION
Depends on #81 (`fix/switch-case-multiple-statements`) — based on its tip.

Two related gaps in `$.structure_type`'s reach, found:

1. `typedef_declaration`'s RHS still listed `$.block` as a choice alongside `$.structure_type` (a leftover from before `$.structure_type` existed as its own rule) -- a bare `identifier : expression` is also a valid one-statement `$.block` via `$.pair`'s low-precedence bare-literal alternative, so a single-field, no-trailing-comma struct (`typedef X = { f:T }`) hard-errored -- `$.block` and `$.structure_type` both matched the same tokens, and tree-sitter's own conflict analysis called it an "unnecessary conflict" (no tie to break) while it still errored at runtime. Fix: replaced `$.block` with a new dedicated `$._structure_class_body` rule restricted to exactly var/function member declarations (aliased to `$.block` so existing consumers/tests see the same node type), which structurally can't overlap with `$.structure_type`'s bare shape.

2. `$.type` had no `$.structure_type` alternative at all, so an anonymous struct could only appear where a call site hand-rolled its own `choice($.type, $.structure_type)` workaround. `cb:String->{}->Void` hard-errored everywhere except that one call site. Fix: added `$.structure_type` as a bare `$.type` choice, so every `$.type` slot gets anonymous-struct support for free.

   **This creates one new, genuine ambiguity, deliberately resolved rather than left to chance.** `(name: {})` can be built two structurally valid ways from the exact same tokens: as a runtime type-check (`name` checked against the empty-struct *type* `{}`) or as a parenthesized, bare pair *expression* (`name` mapped to an empty `object` *value* `{}`). Removing the `[$.object, $.structure_type]` entry from `conflicts` and regenerating confirms tree-sitter treats this as a live, unresolved conflict — not a false positive — and names exactly these two rules as the competing interpretations. Resolved with `prec.dynamic(1)` on `structure_type`, which only breaks the tie once the GLR parser has already forked on a genuinely ambiguous input, rather than a static `prec()` bump, which changes the shift/reduce table globally and (confirmed by testing) breaks unrelated multi-arrow `$.function_type` chains like `String->{}->Void` elsewhere in the grammar.

   Concretely, the tie-break means: `(name: {})` now always parses as the type-check reading (`structure_type`). The pair-expression reading (`name` paired with an empty `object`) becomes unreachable through this specific ambiguous shape — confirmed by temporarily reversing the tie-break and observing the parser fall back to exactly that tree. This is a narrow, low-risk trade-off: a bare parenthesized pair with an empty-object value is a vanishingly rare thing to write in real code (pairs normally appear inside `{}`/`[]` literal delimiters, not floating alone in parens).

Known limitation, not fixed here: a `$.structure_type` segment that ISN'T the last segment of a `$.function_type` chain still fails to extend into a further right-nested `function_type` when the chain's outer context is a variable/field type or a function's return type. Documented in `$.function_type`'s comment and locked in by a corpus test so a future fix is a deliberate, visible change rather than a silent one.

Verified: 234/234 corpus tests pass (4 new).